### PR TITLE
Add media.html and content.html token demos for ui-card

### DIFF
--- a/ui/card/content.html
+++ b/ui/card/content.html
@@ -1,0 +1,263 @@
+<!DOCTYPE html>
+<html lang="en-US" dir="ltr">
+<head>
+	<title>UI: Card — Content</title>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+	<meta name="description" content="Every <ui-content> token in one place: the fs() typographic scale (body + headline), th() themes, the content parts, p() padding, sp() splits, sq() corners, scrollable content and the core surface tokens.">
+	<link rel="stylesheet" href="/ui/base/index.css">
+	<link rel="stylesheet" href="ui-card.css">
+	<style>
+		.grid {
+			display: grid;
+			gap: var(--spacing-lg);
+			grid-template-columns: 1fr;
+			margin-block-end: var(--spacing-2xl);
+		}
+		@media (min-width: 540px) {
+			.grid-2 { grid-template-columns: repeat(2, 1fr); }
+			.grid-3 { grid-template-columns: repeat(3, 1fr); }
+		}
+		@media (min-width: 900px) {
+			.grid-4 { grid-template-columns: repeat(4, 1fr); }
+		}
+		.stack { display: grid; gap: var(--spacing-lg); margin-block-end: var(--spacing-2xl); }
+		.note { color: var(--color-text-secondary, #666); max-inline-size: 70ch; }
+		code { font-size: 0.9em; }
+	</style>
+</head>
+<body>
+	<h1>UI: Card — <code>&lt;ui-content&gt;</code></h1>
+	<p class="note">Everything that controls the content column: the <code>fs()</code> typographic scale (a decoupled body + headline ramp), the <code>th()</code> themes, every <code>data-part</code>, <code>p()</code> padding, <code>sp()</code> column splits, <code>sq()</code> corners, scrollable content, and the core surface tokens. All driven by <code>variant</code> tokens — no JavaScript.</p>
+	<p class="note">See also: <a href="index.html">index.html</a> (the full engine) · <a href="media.html">media.html</a> (the <code>&lt;ui-media&gt;</code> side) · <a href="ui-card-tokens.md">ui-card-tokens.md</a> (token reference).</p>
+
+	<!-- ============================================================
+	     fs() — typographic scale
+	     ============================================================ -->
+	<h2>Typographic scale — <code>fs()</code></h2>
+	<p class="note"><code>fs(sm | md | lg | xl)</code> (default <code>md</code>) sets <strong>two</strong> container-driven <code>clamp()</code> ramps at once — a gentle <em>body</em> scale (eyebrow / summary / meta / tags) and a more aggressive <em>headline</em> scale. Decoupling them means a big card gets a display-size title while the body copy stays readable. Both also grow/shrink with the card's own width (<code>cqi</code>).</p>
+	<div class="grid grid-4">
+		<ui-card variant="vertical content-only fs(sm)" style="--ui-card-media-min: 0;">
+			<cq-box><ui-content>
+				<small data-part="eyebrow">fs(sm)</small>
+				<h2 data-part="headline">Small &amp; tidy</h2>
+				<p data-part="summary">Body and headline both step down. Good for dense grids and metadata-heavy cards.</p>
+			</ui-content></cq-box>
+		</ui-card>
+		<ui-card variant="vertical content-only fs(md)">
+			<cq-box><ui-content>
+				<small data-part="eyebrow">fs(md) — default</small>
+				<h2 data-part="headline">The comfortable default</h2>
+				<p data-part="summary">The baseline ramp used when no <code>fs()</code> is set.</p>
+			</ui-content></cq-box>
+		</ui-card>
+		<ui-card variant="vertical content-only fs(lg)">
+			<cq-box><ui-content>
+				<small data-part="eyebrow">fs(lg)</small>
+				<h2 data-part="headline">Larger headline</h2>
+				<p data-part="summary">Headline jumps ahead of the body — note the gap widening between the two ramps.</p>
+			</ui-content></cq-box>
+		</ui-card>
+		<ui-card variant="vertical content-only fs(xl)">
+			<cq-box><ui-content>
+				<small data-part="eyebrow">fs(xl)</small>
+				<strong data-part="headline">Display</strong>
+				<p data-part="summary">The hero tier — the headline goes display-size while the summary stays around 1.2rem.</p>
+			</ui-content></cq-box>
+		</ui-card>
+	</div>
+	<p class="note">The same scale on a wide card shows how hard the headline ramp pushes at <code>fs(xl)</code> while the body stays readable:</p>
+	<ui-card class="stack" variant="horizontal sp(1/2) content-only fs(xl)">
+		<cq-box><ui-content>
+			<small data-part="eyebrow">fs(xl) · wide container</small>
+			<strong data-part="headline">A display headline that scales with width</strong>
+			<p data-part="summary">Resize the window: the headline tracks the card's own inline-size via <code>cqi</code>, bounded by its <code>clamp()</code>. The summary barely moves — that is the decoupled ramp doing its job.</p>
+		</ui-content></cq-box>
+	</ui-card>
+
+	<!-- ============================================================
+	     Content parts — full anatomy
+	     ============================================================ -->
+	<h2>Content parts — the full anatomy</h2>
+	<p class="note">Parts are styled by the <code>data-part</code> attribute, not the tag name, so you pick the semantically correct element. Each part has its own font-size / colour / weight / gap tokens (all relative to <code>--ui-card-fs</code> by default).</p>
+	<div class="grid grid-2">
+		<ui-card variant="vertical ar(16/9)">
+			<cq-box>
+				<ui-media>
+					<img src="assets/popovers.jpg" alt="">
+					<small data-part="caption" style="position:absolute; inset-block-end:.5rem; inset-inline-start:.5rem; background:rgb(0 0 0/.55); color:#fff; padding:.2em .5em; border-radius:.3em;">caption (inside media)</small>
+				</ui-media>
+				<ui-content>
+					<small data-part="eyebrow">Eyebrow</small>
+					<h2 data-part="headline">Headline part</h2>
+					<p data-part="subheadline">Subheadline — a muted secondary line</p>
+					<p data-part="summary">Summary is the body copy of the card. It uses the body font-size ramp and a comfortable line-height for reading.</p>
+					<address data-part="byline"><img src="assets/janesmith.jpg" alt=""><span>Byline · <span data-part="meta">Jun 20, 2026 · 5 min</span></span></address>
+					<ul data-part="tags"><li><a href="#">tags</a></li><li><a href="#">pill list</a></li></ul>
+					<nav data-part="actions"><a class="ui-button" href="#">Primary action</a></nav>
+					<footer data-part="footer">Footer — trailing meta</footer>
+				</ui-content>
+			</cq-box>
+		</ui-card>
+		<ui-card variant="vertical content-only">
+			<cq-box><ui-content>
+				<small data-part="eyebrow">Reference</small>
+				<h2 data-part="headline">Each part, isolated</h2>
+				<p data-part="subheadline">subheadline → <code>--ui-card-muted</code></p>
+				<p data-part="summary">summary → inherits the body colour, <code>fs × 1</code>.</p>
+				<p data-part="meta">meta → <code>fs × 0.75</code>, muted.</p>
+				<address data-part="byline"><span>byline → <code>fs × 0.82</code> (no avatar here)</span></address>
+				<ul data-part="tags"><li><a href="#">UX</a></li><li><a href="#">CSS</a></li><li><a href="#">Cards</a></li></ul>
+				<nav data-part="actions"><a class="ui-button" href="#">Buy</a> <a class="ui-button --ghost" href="#">Details</a></nav>
+				<footer data-part="footer">footer → <code>fs × 0.78</code>, muted</footer>
+			</ui-content></cq-box>
+		</ui-card>
+	</div>
+
+	<!-- ============================================================
+	     th() — themes
+	     ============================================================ -->
+	<h2>Themes — <code>th()</code></h2>
+	<p class="note">Theme tokens remap the surface, ink, eyebrow and tag colours. The same card in default, <code>th(subtle)</code>, <code>th(dark)</code> and <code>th(brand)</code>. Every value is overridable (e.g. <code>--ui-card-dark-bg</code>, <code>--ui-card-brand-ink</code>).</p>
+	<div class="grid grid-4">
+		<ui-card variant="vertical ar(16/9)">
+			<cq-box>
+				<ui-media><img src="assets/fittrackpro.jpg" alt=""></ui-media>
+				<ui-content><small data-part="eyebrow">default</small><h2 data-part="headline">FitTrack Pro</h2><p data-part="summary">Unlimited workouts, coaching and priority support.</p><ul data-part="tags"><li><a href="#">Popular</a></li></ul><nav data-part="actions"><a class="ui-button" href="#">Choose</a></nav></ui-content>
+			</cq-box>
+		</ui-card>
+		<ui-card variant="vertical ar(16/9) th(subtle)">
+			<cq-box>
+				<ui-media><img src="assets/fittrackpro.jpg" alt=""></ui-media>
+				<ui-content><small data-part="eyebrow">th(subtle)</small><h2 data-part="headline">FitTrack Pro</h2><p data-part="summary">Off-white surface, default dark ink.</p><ul data-part="tags"><li><a href="#">Popular</a></li></ul><nav data-part="actions"><a class="ui-button" href="#">Choose</a></nav></ui-content>
+			</cq-box>
+		</ui-card>
+		<ui-card variant="vertical ar(16/9) th(dark)">
+			<cq-box>
+				<ui-media><img src="assets/fittrackpro.jpg" alt=""></ui-media>
+				<ui-content><small data-part="eyebrow">th(dark)</small><h2 data-part="headline">FitTrack Pro</h2><p data-part="summary">Dark surface, light ink, accent eyebrow.</p><ul data-part="tags"><li><a href="#">Popular</a></li></ul><nav data-part="actions"><a class="ui-button" href="#">Choose</a></nav></ui-content>
+			</cq-box>
+		</ui-card>
+		<ui-card variant="vertical ar(16/9) th(brand)">
+			<cq-box>
+				<ui-media><img src="assets/fittrackpro.jpg" alt=""></ui-media>
+				<ui-content><small data-part="eyebrow">th(brand)</small><h2 data-part="headline">FitTrack Pro</h2><p data-part="summary">Accent surface, white ink.</p><ul data-part="tags"><li><a href="#">Popular</a></li></ul><nav data-part="actions"><a class="ui-button" href="#">Choose</a></nav></ui-content>
+			</cq-box>
+		</ui-card>
+	</div>
+
+	<!-- ============================================================
+	     p() — content padding
+	     ============================================================ -->
+	<h2>Padding — <code>p()</code></h2>
+	<p class="note"><code>p(none | xs | sm | md | lg | xl | 2xl)</code> sets the content padding (mapped to the global <code>--spacing-*</code> scale). Default is <code>md</code>.</p>
+	<div class="grid grid-4">
+		<ui-card variant="vertical content-only th(subtle) p(none)"><cq-box><ui-content><small data-part="eyebrow">p(none)</small><h2 data-part="headline">Flush</h2><p data-part="summary">No padding at all.</p></ui-content></cq-box></ui-card>
+		<ui-card variant="vertical content-only th(subtle) p(sm)"><cq-box><ui-content><small data-part="eyebrow">p(sm)</small><h2 data-part="headline">Snug</h2><p data-part="summary">Small spacing.</p></ui-content></cq-box></ui-card>
+		<ui-card variant="vertical content-only th(subtle) p(lg)"><cq-box><ui-content><small data-part="eyebrow">p(lg)</small><h2 data-part="headline">Roomy</h2><p data-part="summary">Large spacing.</p></ui-content></cq-box></ui-card>
+		<ui-card variant="vertical content-only th(subtle) p(2xl)"><cq-box><ui-content><small data-part="eyebrow">p(2xl)</small><h2 data-part="headline">Generous</h2><p data-part="summary">Maximum spacing.</p></ui-content></cq-box></ui-card>
+	</div>
+	<p class="note">The space between content rows is a separate knob — <code>--ui-card-row-gap</code> (default <code>1em</code>):</p>
+	<div class="grid grid-3">
+		<ui-card variant="vertical content-only th(subtle)" style="--ui-card-row-gap: 0.25em;"><cq-box><ui-content><small data-part="eyebrow">row-gap 0.25em</small><h2 data-part="headline">Tight rows</h2><p data-part="summary">Rows pulled close together.</p><nav data-part="actions"><a class="ui-button" href="#">Go</a></nav></ui-content></cq-box></ui-card>
+		<ui-card variant="vertical content-only th(subtle)"><cq-box><ui-content><small data-part="eyebrow">row-gap 1em</small><h2 data-part="headline">Default rows</h2><p data-part="summary">The baseline rhythm.</p><nav data-part="actions"><a class="ui-button" href="#">Go</a></nav></ui-content></cq-box></ui-card>
+		<ui-card variant="vertical content-only th(subtle)" style="--ui-card-row-gap: 2em;"><cq-box><ui-content><small data-part="eyebrow">row-gap 2em</small><h2 data-part="headline">Airy rows</h2><p data-part="summary">Rows pushed apart.</p><nav data-part="actions"><a class="ui-button" href="#">Go</a></nav></ui-content></cq-box></ui-card>
+	</div>
+
+	<!-- ============================================================
+	     Arrangement & sp() splits
+	     ============================================================ -->
+	<h2>Arrangement &amp; split — <code>horizontal</code> / <code>sp()</code></h2>
+	<p class="note">Beyond <code>vertical</code> (default), content can sit beside the media (<code>horizontal</code>), before it (<code>vertical-r</code> / <code>horizontal-r</code>), and the column ratio is set with <code>sp(1/1 | 1/2 | 2/1 | 1/3 | 3/1)</code>.</p>
+	<div class="stack">
+		<ui-card variant="horizontal sp(1/2) ar(1/1)">
+			<cq-box>
+				<ui-media><img src="assets/ergochair.jpg" alt=""></ui-media>
+				<ui-content><small data-part="eyebrow">horizontal sp(1/2)</small><h2 data-part="headline">ErgoChair Pro</h2><p data-part="subheadline">USD 349 · free shipping</p><p data-part="summary">Media takes one third, content two thirds. Adaptive lumbar support and a 12-year warranty.</p><nav data-part="actions"><a class="ui-button" href="#">Add to cart</a></nav></ui-content>
+			</cq-box>
+		</ui-card>
+		<ui-card variant="horizontal-r sp(2/1) ar(1/1)">
+			<cq-box>
+				<ui-media><img src="assets/janesmith.jpg" alt=""></ui-media>
+				<ui-content><small data-part="eyebrow">horizontal-r sp(2/1)</small><h2 data-part="headline">Jane Smith</h2><p data-part="subheadline">Chief Political Correspondent</p><p data-part="summary">Content first, media second (reversed), content twice as wide.</p><nav data-part="actions"><a class="ui-button" href="#">View profile</a></nav></ui-content>
+			</cq-box>
+		</ui-card>
+	</div>
+
+	<!-- ============================================================
+	     Overlay content — ov()
+	     ============================================================ -->
+	<h2>Overlay content — <code>ov()</code></h2>
+	<p class="note"><code>ov(pos)</code> stacks the content <em>over</em> the media and places it with the 9-code grid. Overlaid text defaults to white (set <code>--ui-card-overlay-ink</code> for light images). Pair with <code>sc</code> for a scrim — see <a href="media.html">media.html</a>.</p>
+	<div class="grid grid-3">
+		<ui-card variant="ov(tl) sc ar(3/4) op(cc) fs(lg)"><cq-box><ui-media><img src="assets/mindfulness.jpg" alt=""></ui-media><ui-content><small data-part="eyebrow">ov(tl)</small><strong data-part="headline">Top-left</strong></ui-content></cq-box></ui-card>
+		<ui-card variant="ov(cc) sc ar(3/4) op(cc) fs(lg)"><cq-box><ui-media><img src="assets/hubble.jpg" alt=""></ui-media><ui-content><small data-part="eyebrow">ov(cc)</small><strong data-part="headline">Centre</strong></ui-content></cq-box></ui-card>
+		<ui-card variant="ov(br) sc ar(3/4) op(cc) fs(lg)"><cq-box><ui-media><img src="assets/brewandbean.jpg" alt=""></ui-media><ui-content><small data-part="eyebrow">ov(br)</small><strong data-part="headline">Bottom-right</strong></ui-content></cq-box></ui-card>
+	</div>
+
+	<!-- ============================================================
+	     sq() — squircle corners
+	     ============================================================ -->
+	<h2>Squircle corners — <code>sq()</code></h2>
+	<p class="note"><code>sq(sm | md | lg | xl)</code> switches the host to a superellipse <code>corner-shape</code> and a matching radius — the smooth "squircle" corner. (Chromium-only; degrades to a normal radius elsewhere.)</p>
+	<div class="grid grid-4">
+		<ui-card variant="vertical ar(4/3) sq(sm)"><cq-box><ui-media><img src="assets/gastronomy.jpg" alt=""></ui-media><ui-content><small data-part="eyebrow">sq(sm)</small><h2 data-part="headline">Subtle</h2></ui-content></cq-box></ui-card>
+		<ui-card variant="vertical ar(4/3) sq(md)"><cq-box><ui-media><img src="assets/destinations.jpg" alt=""></ui-media><ui-content><small data-part="eyebrow">sq(md)</small><h2 data-part="headline">Medium</h2></ui-content></cq-box></ui-card>
+		<ui-card variant="vertical ar(4/3) sq(lg)"><cq-box><ui-media><img src="assets/river.jpg" alt=""></ui-media><ui-content><small data-part="eyebrow">sq(lg)</small><h2 data-part="headline">Large</h2></ui-content></cq-box></ui-card>
+		<ui-card variant="vertical ar(4/3) sq(xl)"><cq-box><ui-media><img src="assets/websummit.jpg" alt=""></ui-media><ui-content><small data-part="eyebrow">sq(xl)</small><h2 data-part="headline">Extra</h2></ui-content></cq-box></ui-card>
+	</div>
+
+	<!-- ============================================================
+	     Scrollable content — [scroll]
+	     ============================================================ -->
+	<h2>Scrollable content — <code>[scroll]</code></h2>
+	<p class="note">Add the <code>scroll</code> attribute to cap the content height and make it scroll, with a CSS-only fade-shadow on the masked edges (a scroll-driven animation). Cap the height with <code>--ui-card-scroll-bs</code>.</p>
+	<div class="grid grid-2">
+		<ui-card variant="horizontal sp(1/1) ar(1/1)" scroll style="--ui-card-scroll-bs: 18rem;">
+			<cq-box>
+				<ui-media><img src="assets/quantum.jpg" alt=""></ui-media>
+				<ui-content>
+					<small data-part="eyebrow">scroll</small>
+					<h2 data-part="headline">A long read</h2>
+					<p data-part="summary">Scientists have made a breakthrough in quantum computing that could change everything we know about processing power.</p>
+					<p data-part="summary">The implications stretch across cryptography, materials science and drug discovery — fields long bottlenecked by classical compute.</p>
+					<p data-part="summary">As you scroll, the top and bottom edges fade via a <code>mask</code> animated on a <code>scroll-timeline</code> — no JavaScript.</p>
+					<p data-part="summary">When you reach the bottom, the trailing fade lifts so the final line is fully visible.</p>
+					<p data-part="summary">Resize the card and the cap still holds at <code>--ui-card-scroll-bs</code>.</p>
+				</ui-content>
+			</cq-box>
+		</ui-card>
+		<ui-card variant="content-only" scroll style="--ui-card-scroll-bs: 18rem;">
+			<cq-box>
+				<ui-content>
+					<small data-part="eyebrow">content-only · scroll</small>
+					<h2 data-part="headline">Terms &amp; conditions</h2>
+					<p data-part="summary">1. The card body is the only column here — no media frame.</p>
+					<p data-part="summary">2. The same fade-shadow applies; the mask follows the scroll position.</p>
+					<p data-part="summary">3. Long policy text, changelogs and FAQs fit this pattern well.</p>
+					<p data-part="summary">4. Everything stays within the card's rounded clip.</p>
+					<p data-part="summary">5. Scroll on to confirm the bottom fade releases at the end.</p>
+					<p data-part="summary">6. The end.</p>
+				</ui-content>
+			</cq-box>
+		</ui-card>
+	</div>
+
+	<!-- ============================================================
+	     Core surface tokens
+	     ============================================================ -->
+	<h2>Core surface tokens</h2>
+	<p class="note">The card surface itself is tokenised: <code>--ui-card-bg</code>, <code>--ui-card-radius</code> and <code>--ui-card-shadow</code>. Override globally or per instance.</p>
+	<div class="grid grid-3">
+		<ui-card variant="vertical content-only th(subtle)" style="--ui-card-radius: 0; --ui-card-shadow: none; border: 1px solid var(--color-border, #ddd);">
+			<cq-box><ui-content><small data-part="eyebrow">flat</small><h2 data-part="headline">No radius, no shadow</h2><p data-part="summary">A square, bordered card.</p></ui-content></cq-box>
+		</ui-card>
+		<ui-card variant="vertical content-only" style="--ui-card-radius: var(--radius-md, 0.5rem); --ui-card-shadow: var(--shadow-sm);">
+			<cq-box><ui-content><small data-part="eyebrow">soft</small><h2 data-part="headline">Small radius + shadow</h2><p data-part="summary">A lighter, subtler surface.</p></ui-content></cq-box>
+		</ui-card>
+		<ui-card variant="vertical content-only" style="--ui-card-bg: linear-gradient(135deg, #6366f1, #ec4899); color: #fff;">
+			<cq-box><ui-content><small data-part="eyebrow" style="--ui-card-eyebrow-color: rgb(255 255 255 / 0.8);">gradient bg</small><h2 data-part="headline">Custom background</h2><p data-part="summary"><code>--ui-card-bg</code> takes any background value — including a gradient.</p></ui-content></cq-box>
+		</ui-card>
+	</div>
+</body>
+</html>

--- a/ui/card/media.html
+++ b/ui/card/media.html
@@ -1,0 +1,359 @@
+<!DOCTYPE html>
+<html lang="en-US" dir="ltr">
+<head>
+	<title>UI: Card — Media</title>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+	<meta name="description" content="Every <ui-media> token in one place: ar() aspect-ratios, op() object-position, fl() flip, hv() hover effects, scrim, ribbon/badge overlays, video and carousels.">
+	<link rel="stylesheet" href="/ui/base/index.css">
+	<link rel="stylesheet" href="ui-card.css">
+	<style>
+		.grid {
+			display: grid;
+			gap: var(--spacing-lg);
+			grid-template-columns: 1fr;
+			margin-block-end: var(--spacing-2xl);
+		}
+		@media (min-width: 540px) {
+			.grid-2 { grid-template-columns: repeat(2, 1fr); }
+			.grid-3 { grid-template-columns: repeat(3, 1fr); }
+			.grid-4 { grid-template-columns: repeat(2, 1fr); }
+		}
+		@media (min-width: 900px) {
+			.grid-4 { grid-template-columns: repeat(4, 1fr); }
+		}
+		.note { color: var(--color-text-secondary, #666); max-inline-size: 70ch; }
+		.hero { margin-block-end: var(--spacing-2xl); }
+		code { font-size: 0.9em; }
+		/* carousel arrows as inline-SVG chevrons via url() (stroke baked into the SVG) */
+		.svg-arrows {
+			--ui-card-arrow-prev: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='18' height='18' viewBox='0 0 24 24' fill='none' stroke='%23fff' stroke-width='3' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M15 18l-6-6 6-6'/%3E%3C/svg%3E");
+			--ui-card-arrow-next: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='18' height='18' viewBox='0 0 24 24' fill='none' stroke='%23fff' stroke-width='3' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M9 18l6-6-6-6'/%3E%3C/svg%3E");
+		}
+	</style>
+</head>
+<body>
+	<h1>UI: Card — <code>&lt;ui-media&gt;</code></h1>
+	<p class="note">Everything that controls the media frame: the <code>ar()</code> aspect-ratios, <code>op()</code> object-position, <code>fl()</code> flip, <code>hv()</code> hover effects, the <code>sc()</code> scrim, ribbon/badge overlays, <code>&lt;video&gt;</code> and the CSS-only <code>carousel</code>. All driven by <code>variant</code> tokens — no JavaScript (the one exception, cursor-tracked <code>hv(track)</code>, is noted inline).</p>
+	<p class="note">See also: <a href="index.html">index.html</a> (the full engine) · <a href="content.html">content.html</a> (the <code>&lt;ui-content&gt;</code> side) · <a href="ui-card-tokens.md">ui-card-tokens.md</a> (token reference).</p>
+
+	<!-- ============================================================
+	     ar() — aspect-ratio
+	     ============================================================ -->
+	<h2>Aspect-ratio — <code>ar()</code></h2>
+	<p class="note">Sets the media frame's <code>aspect-ratio</code> (and drops its <code>min-block-size</code> so the ratio wins). Eight stops cover the common print/screen ratios. Same image, same width — only the crop changes.</p>
+	<div class="grid grid-4">
+		<ui-card variant="media-only ar(1/1)">
+			<cq-box><ui-media><img src="assets/destinations.jpg" alt=""><span data-part="badge" pos="bl">ar(1/1)</span></ui-media></cq-box>
+		</ui-card>
+		<ui-card variant="media-only ar(6/7)">
+			<cq-box><ui-media><img src="assets/destinations.jpg" alt=""><span data-part="badge" pos="bl">ar(6/7)</span></ui-media></cq-box>
+		</ui-card>
+		<ui-card variant="media-only ar(3/4)">
+			<cq-box><ui-media><img src="assets/destinations.jpg" alt=""><span data-part="badge" pos="bl">ar(3/4)</span></ui-media></cq-box>
+		</ui-card>
+		<ui-card variant="media-only ar(2/3)">
+			<cq-box><ui-media><img src="assets/destinations.jpg" alt=""><span data-part="badge" pos="bl">ar(2/3)</span></ui-media></cq-box>
+		</ui-card>
+		<ui-card variant="media-only ar(4/3)">
+			<cq-box><ui-media><img src="assets/destinations.jpg" alt=""><span data-part="badge" pos="bl">ar(4/3)</span></ui-media></cq-box>
+		</ui-card>
+		<ui-card variant="media-only ar(3/2)">
+			<cq-box><ui-media><img src="assets/destinations.jpg" alt=""><span data-part="badge" pos="bl">ar(3/2)</span></ui-media></cq-box>
+		</ui-card>
+		<ui-card variant="media-only ar(16/9)">
+			<cq-box><ui-media><img src="assets/destinations.jpg" alt=""><span data-part="badge" pos="bl">ar(16/9)</span></ui-media></cq-box>
+		</ui-card>
+		<ui-card variant="media-only ar(21/9)">
+			<cq-box><ui-media><img src="assets/destinations.jpg" alt=""><span data-part="badge" pos="bl">ar(21/9)</span></ui-media></cq-box>
+		</ui-card>
+	</div>
+	<p class="note">Without an <code>ar()</code>, the frame falls back to its natural image height (bounded by <code>--ui-card-media-min</code>, default <code>12.5rem</code>).</p>
+
+	<!-- ============================================================
+	     op() — object-position
+	     ============================================================ -->
+	<h2>Object-position — <code>op()</code></h2>
+	<p class="note">When the frame's ratio crops the image, <code>op()</code> picks <em>which</em> part stays in view — the same 9-code grid used everywhere else: <code>tl tc tr · cl cc cr · bl bc br</code>. All nine below share one square frame and one wide image.</p>
+	<div class="grid grid-3">
+		<ui-card variant="media-only ar(1/1) op(tl)"><cq-box><ui-media><img src="assets/government.jpg" alt=""><span data-part="badge" pos="tc">op(tl)</span></ui-media></cq-box></ui-card>
+		<ui-card variant="media-only ar(1/1) op(tc)"><cq-box><ui-media><img src="assets/government.jpg" alt=""><span data-part="badge" pos="tc">op(tc)</span></ui-media></cq-box></ui-card>
+		<ui-card variant="media-only ar(1/1) op(tr)"><cq-box><ui-media><img src="assets/government.jpg" alt=""><span data-part="badge" pos="tc">op(tr)</span></ui-media></cq-box></ui-card>
+		<ui-card variant="media-only ar(1/1) op(cl)"><cq-box><ui-media><img src="assets/government.jpg" alt=""><span data-part="badge" pos="tc">op(cl)</span></ui-media></cq-box></ui-card>
+		<ui-card variant="media-only ar(1/1) op(cc)"><cq-box><ui-media><img src="assets/government.jpg" alt=""><span data-part="badge" pos="tc">op(cc)</span></ui-media></cq-box></ui-card>
+		<ui-card variant="media-only ar(1/1) op(cr)"><cq-box><ui-media><img src="assets/government.jpg" alt=""><span data-part="badge" pos="tc">op(cr)</span></ui-media></cq-box></ui-card>
+		<ui-card variant="media-only ar(1/1) op(bl)"><cq-box><ui-media><img src="assets/government.jpg" alt=""><span data-part="badge" pos="tc">op(bl)</span></ui-media></cq-box></ui-card>
+		<ui-card variant="media-only ar(1/1) op(bc)"><cq-box><ui-media><img src="assets/government.jpg" alt=""><span data-part="badge" pos="tc">op(bc)</span></ui-media></cq-box></ui-card>
+		<ui-card variant="media-only ar(1/1) op(br)"><cq-box><ui-media><img src="assets/government.jpg" alt=""><span data-part="badge" pos="tc">op(br)</span></ui-media></cq-box></ui-card>
+	</div>
+
+	<!-- ============================================================
+	     object-fit token
+	     ============================================================ -->
+	<h2>Object-fit — <code>--ui-card-object-fit</code></h2>
+	<p class="note">The frame defaults to <code>object-fit: cover</code> (fill &amp; crop). Override the token per instance for <code>contain</code> (letterbox, whole image visible) — handy for logos and product shots that must not crop.</p>
+	<div class="grid grid-3">
+		<ui-card variant="media-only ar(1/1)"><cq-box><ui-media><img src="assets/ergochair.jpg" alt=""><span data-part="badge" pos="bl">cover (default)</span></ui-media></cq-box></ui-card>
+		<ui-card variant="media-only ar(1/1)" style="--ui-card-object-fit: contain; --ui-card-media-bg: var(--color-surface-alt, #f1f1f1);"><cq-box><ui-media><img src="assets/ergochair.jpg" alt=""><span data-part="badge" pos="bl">contain</span></ui-media></cq-box></ui-card>
+		<ui-card variant="media-only ar(1/1)" style="--ui-card-object-fit: fill;"><cq-box><ui-media><img src="assets/ergochair.jpg" alt=""><span data-part="badge" pos="bl">fill</span></ui-media></cq-box></ui-card>
+	</div>
+
+	<!-- ============================================================
+	     fl() — flip / mirror
+	     ============================================================ -->
+	<h2>Flip — <code>fl()</code></h2>
+	<p class="note">Mirror the media without editing the asset. <code>fl(h)</code> flips horizontally, <code>fl(v)</code> vertically, <code>fl(hv)</code> both. It uses <code>transform</code> on the image, separate from the scale/translate that <code>hv()</code> drives, so flip and hover compose.</p>
+	<div class="grid grid-4">
+		<ui-card variant="media-only ar(4/3)"><cq-box><ui-media><img src="assets/river.jpg" alt=""><span data-part="badge" pos="bl">original</span></ui-media></cq-box></ui-card>
+		<ui-card variant="media-only ar(4/3) fl(h)"><cq-box><ui-media><img src="assets/river.jpg" alt=""><span data-part="badge" pos="bl">fl(h)</span></ui-media></cq-box></ui-card>
+		<ui-card variant="media-only ar(4/3) fl(v)"><cq-box><ui-media><img src="assets/river.jpg" alt=""><span data-part="badge" pos="bl">fl(v)</span></ui-media></cq-box></ui-card>
+		<ui-card variant="media-only ar(4/3) fl(hv)"><cq-box><ui-media><img src="assets/river.jpg" alt=""><span data-part="badge" pos="bl">fl(hv)</span></ui-media></cq-box></ui-card>
+	</div>
+
+	<!-- ============================================================
+	     hv() — hover effects
+	     ============================================================ -->
+	<h2>Hover effects — <code>hv()</code></h2>
+	<p class="note">Hover (or focus) a card. <code>zoom</code> / <code>pan</code> / <code>track</code> move the <em>image</em> inside a fixed frame; <code>lift</code> / <code>shrink</code> / <code>tilt</code> transform the whole <em>card</em>. Tune with <code>--ui-card-hv-*</code> and <code>--ui-card-hover-duration</code>. All respect <code>prefers-reduced-motion</code>.</p>
+	<div class="grid grid-3">
+		<ui-card variant="vertical ar(16/9) hv(zoom)">
+			<cq-box>
+				<ui-media><img src="assets/mindfulness.jpg" alt=""></ui-media>
+				<ui-content><small data-part="eyebrow">image</small><h2 data-part="headline">hv(zoom)</h2><p data-part="summary">The image scales up inside the frame.</p></ui-content>
+			</cq-box>
+		</ui-card>
+		<ui-card variant="vertical ar(16/9) hv(pan)">
+			<cq-box>
+				<ui-media><img src="assets/hubble.jpg" alt=""></ui-media>
+				<ui-content><small data-part="eyebrow">image</small><h2 data-part="headline">hv(pan)</h2><p data-part="summary">Zooms and drifts in a fixed direction.</p></ui-content>
+			</cq-box>
+		</ui-card>
+		<ui-card class="track" variant="vertical ar(16/9) hv(track)">
+			<cq-box>
+				<ui-media><img src="assets/quantum.jpg" alt=""></ui-media>
+				<ui-content><small data-part="eyebrow">image · needs JS</small><h2 data-part="headline">hv(track)</h2><p data-part="summary">The image follows the cursor — the only effect that needs a tiny pointer handler (below).</p></ui-content>
+			</cq-box>
+		</ui-card>
+		<ui-card variant="vertical ar(16/9) hv(lift)">
+			<cq-box>
+				<ui-media><img src="assets/websummit.jpg" alt=""></ui-media>
+				<ui-content><small data-part="eyebrow">card</small><h2 data-part="headline">hv(lift)</h2><p data-part="summary">The card rises with a deeper shadow.</p></ui-content>
+			</cq-box>
+		</ui-card>
+		<ui-card variant="vertical ar(16/9) hv(shrink)">
+			<cq-box>
+				<ui-media><img src="assets/gastronomy.jpg" alt=""></ui-media>
+				<ui-content><small data-part="eyebrow">card</small><h2 data-part="headline">hv(shrink)</h2><p data-part="summary">The card scales down slightly — a press-in feel.</p></ui-content>
+			</cq-box>
+		</ui-card>
+		<ui-card variant="vertical ar(16/9) hv(tilt)">
+			<cq-box>
+				<ui-media><img src="assets/brewandbean.jpg" alt=""></ui-media>
+				<ui-content><small data-part="eyebrow">card</small><h2 data-part="headline">hv(tilt)</h2><p data-part="summary">The card rotates a degree or two.</p></ui-content>
+			</cq-box>
+		</ui-card>
+	</div>
+
+	<!-- ============================================================
+	     sc() / ov() — scrim over media
+	     ============================================================ -->
+	<h2>Scrim — <code>sc()</code> over media</h2>
+	<p class="note">A <strong>scrim</strong> is the darkening gradient painted over the image (via <code>ui-media::after</code>) so overlaid text stays legible. <code>ov(pos)</code> places the content over the media; bare <code>sc</code> auto-matches that position, or pass an explicit <code>sc(pos)</code>. The colour is the <code>--ui-card-scrim-color</code> token.</p>
+	<div class="grid grid-3">
+		<ui-card variant="ov(bl) ar(3/4) op(cc) fs(lg)">
+			<cq-box>
+				<ui-media><img src="assets/mindfulness.jpg" alt=""></ui-media>
+				<ui-content><small data-part="eyebrow">ov(bl) — no scrim</small><strong data-part="headline">Placed, undimmed</strong></ui-content>
+			</cq-box>
+		</ui-card>
+		<ui-card variant="ov(bl) sc ar(3/4) op(cc) fs(lg)">
+			<cq-box>
+				<ui-media><img src="assets/mindfulness.jpg" alt=""></ui-media>
+				<ui-content><small data-part="eyebrow">ov(bl) sc — auto-match</small><strong data-part="headline">Bottom scrim</strong></ui-content>
+			</cq-box>
+		</ui-card>
+		<ui-card variant="ov(cc) sc(cc) ar(3/4) op(cc) fs(lg)" style="--ui-card-scrim-color: rgb(20 0 40 / 0.7);">
+			<cq-box>
+				<ui-media><img src="assets/hubble.jpg" alt=""></ui-media>
+				<ui-content><small data-part="eyebrow">sc(cc) + custom colour</small><strong data-part="headline">Centre band</strong></ui-content>
+			</cq-box>
+		</ui-card>
+	</div>
+
+	<!-- ============================================================
+	     Ribbon & badge overlays
+	     ============================================================ -->
+	<h2>Media overlays — ribbon &amp; badge</h2>
+	<p class="note">Place <code>data-part="ribbon"</code> or <code>data-part="badge"</code> <strong>inside <code>&lt;ui-media&gt;</code></strong>. Both use the same 9-code <code>pos()</code> placement and <code>color="info|success|warning|error"</code> for the semantic palette. A ribbon can also be <code>variant="diagonal"</code> (corner positions only).</p>
+	<div class="grid grid-3">
+		<ui-card variant="vertical ar(4/3)">
+			<cq-box>
+				<ui-media>
+					<img src="assets/aurasoundpro.jpg" alt="">
+					<span data-part="ribbon" pos="tl" color="error">Featured</span>
+					<span data-part="badge" pos="br" color="success">New</span>
+				</ui-media>
+				<ui-content><small data-part="eyebrow">Audio</small><h2 data-part="headline">Straight ribbon + badge</h2></ui-content>
+			</cq-box>
+		</ui-card>
+		<ui-card variant="vertical ar(4/3)">
+			<cq-box>
+				<ui-media>
+					<img src="assets/ergochair.jpg" alt="">
+					<span data-part="ribbon" pos="tr" variant="diagonal" color="error">-28%</span>
+				</ui-media>
+				<ui-content><small data-part="eyebrow">Furniture</small><h2 data-part="headline">Diagonal ribbon</h2></ui-content>
+			</cq-box>
+		</ui-card>
+		<ui-card variant="vertical ar(4/3)">
+			<cq-box>
+				<ui-media>
+					<img src="assets/brewandbean.jpg" alt="">
+					<span data-part="ribbon" pos="bl">Editor's pick</span>
+					<span data-part="badge" pos="tr" color="warning">Sale</span>
+				</ui-media>
+				<ui-content><small data-part="eyebrow">Café</small><h2 data-part="headline">Accent ribbon + warning badge</h2></ui-content>
+			</cq-box>
+		</ui-card>
+	</div>
+	<p class="note">The four diagonal-ribbon corners (<code>tl tr bl br</code>):</p>
+	<div class="grid grid-4">
+		<ui-card variant="media-only ar(1/1)"><cq-box><ui-media><img src="assets/popovers.jpg" alt=""><span data-part="ribbon" pos="tl" variant="diagonal" color="info">tl</span></ui-media></cq-box></ui-card>
+		<ui-card variant="media-only ar(1/1)"><cq-box><ui-media><img src="assets/popovers.jpg" alt=""><span data-part="ribbon" pos="tr" variant="diagonal" color="success">tr</span></ui-media></cq-box></ui-card>
+		<ui-card variant="media-only ar(1/1)"><cq-box><ui-media><img src="assets/popovers.jpg" alt=""><span data-part="ribbon" pos="bl" variant="diagonal" color="warning">bl</span></ui-media></cq-box></ui-card>
+		<ui-card variant="media-only ar(1/1)"><cq-box><ui-media><img src="assets/popovers.jpg" alt=""><span data-part="ribbon" pos="br" variant="diagonal" color="error">br</span></ui-media></cq-box></ui-card>
+	</div>
+
+	<!-- ============================================================
+	     Video
+	     ============================================================ -->
+	<h2>Video</h2>
+	<p class="note">A native <code>&lt;video&gt;</code> fills the frame exactly like an image — same <code>object-fit: cover</code>, same <code>ar()</code>. Use native attributes (controls, poster, muted, loop); no JS.</p>
+	<div class="grid grid-2">
+		<ui-card variant="vertical ar(16/9)">
+			<cq-box>
+				<ui-media>
+					<video src="https://assets.stoumann.dk/video/river.mp4" poster="assets/river.jpg" controls muted loop playsinline></video>
+					<span data-part="badge" pos="tl" color="info">Video</span>
+				</ui-media>
+				<ui-content><small data-part="eyebrow">Nature</small><h2 data-part="headline">A quieter river</h2><p data-part="summary">Native <code>&lt;video&gt;</code> with the same cover-fit as an image.</p></ui-content>
+			</cq-box>
+		</ui-card>
+		<ui-card variant="media-only ar(16/9)">
+			<cq-box>
+				<ui-media>
+					<video src="https://assets.stoumann.dk/video/river.mp4" poster="assets/river.jpg" autoplay muted loop playsinline></video>
+					<span data-part="ribbon" pos="bl">media-only · autoplay loop</span>
+				</ui-media>
+			</cq-box>
+		</ui-card>
+	</div>
+
+	<!-- ============================================================
+	     Carousel — default
+	     ============================================================ -->
+	<h2>Carousel — <code>variant="carousel"</code></h2>
+	<p class="note">Add the <code>carousel</code> token to put <strong>multiple sources</strong> in a scroll-snap row. By default it shows CSS-only navigation — dots (<code>::scroll-marker</code>) and prev/next arrows (<code>::scroll-button()</code>) — with no extra markup and no JS. Chromium-only for now; elsewhere it degrades to a plain swipe scroller.</p>
+	<div class="grid grid-2">
+		<ui-card variant="carousel vertical ar(16/9) fs(lg)">
+			<cq-box>
+				<ui-media>
+					<img src="assets/destinations.jpg" alt="">
+					<img src="assets/river.jpg" alt="">
+					<img src="assets/mindfulness.jpg" alt="">
+					<img src="assets/gastronomy.jpg" alt="">
+				</ui-media>
+				<ui-content><small data-part="eyebrow">Travel</small><h2 data-part="headline">Dots + arrows (default)</h2><p data-part="summary">Swipe, tap a dot, or click an arrow.</p></ui-content>
+			</cq-box>
+		</ui-card>
+		<ui-card variant="carousel horizontal sp(1/1) ar(1/1) fs(md)">
+			<cq-box>
+				<ui-media>
+					<img src="assets/hubble.jpg" alt="">
+					<img src="assets/quantum.jpg" alt="">
+					<img src="assets/websummit.jpg" alt="">
+				</ui-media>
+				<ui-content><small data-part="eyebrow">Science</small><h2 data-part="headline">Carousel beside content</h2><p data-part="summary">A carousel works in any arrangement — here it is the media half of a <code>horizontal</code> card.</p><nav data-part="actions"><a class="ui-button" href="#">Explore</a></nav></ui-content>
+			</cq-box>
+		</ui-card>
+	</div>
+
+	<!-- ============================================================
+	     Carousel controls
+	     ============================================================ -->
+	<h2>Carousel controls — the <code>controls</code> attribute</h2>
+	<p class="note">Pick which controls show with <code>controls="dots arrows none"</code> (space-separated). <code>controls="none"</code> leaves a bare swipe scroller — there is no separate gallery variant; a carousel with its controls off <em>is</em> the gallery.</p>
+	<div class="grid grid-4">
+		<ui-card variant="carousel vertical ar(4/3) fs(sm)" controls="dots">
+			<cq-box>
+				<ui-media><img src="assets/destinations.jpg" alt=""><img src="assets/river.jpg" alt=""><img src="assets/mindfulness.jpg" alt=""></ui-media>
+				<ui-content><small data-part="eyebrow">controls="dots"</small><h2 data-part="headline">Dots only</h2></ui-content>
+			</cq-box>
+		</ui-card>
+		<ui-card variant="carousel vertical ar(4/3) fs(sm)" controls="arrows">
+			<cq-box>
+				<ui-media><img src="assets/gastronomy.jpg" alt=""><img src="assets/brewandbean.jpg" alt=""><img src="assets/aurasoundpro.jpg" alt=""></ui-media>
+				<ui-content><small data-part="eyebrow">controls="arrows"</small><h2 data-part="headline">Arrows only</h2></ui-content>
+			</cq-box>
+		</ui-card>
+		<ui-card variant="carousel vertical ar(4/3) fs(sm)" controls="dots arrows">
+			<cq-box>
+				<ui-media><img src="assets/hubble.jpg" alt=""><img src="assets/quantum.jpg" alt=""><img src="assets/websummit.jpg" alt=""></ui-media>
+				<ui-content><small data-part="eyebrow">controls="dots arrows"</small><h2 data-part="headline">Both</h2></ui-content>
+			</cq-box>
+		</ui-card>
+		<ui-card variant="carousel vertical ar(4/3) fs(sm)" controls="none">
+			<cq-box>
+				<ui-media><img src="assets/popovers.jpg" alt=""><img src="assets/government.jpg" alt=""><img src="assets/fittrackpro.jpg" alt=""><span data-part="badge" pos="tr">3 photos</span></ui-media>
+				<ui-content><small data-part="eyebrow">controls="none"</small><h2 data-part="headline">Bare swipe scroller</h2></ui-content>
+			</cq-box>
+		</ui-card>
+	</div>
+
+	<!-- ============================================================
+	     Carousel theming
+	     ============================================================ -->
+	<h2>Carousel theming</h2>
+	<p class="note">Every colour, size and glyph is a token. Recolour the dots and arrows with <code>--ui-card-dot-*</code> / <code>--ui-card-arrow-*</code>, resize them, or swap the chevron for your own <code>url()</code> SVG.</p>
+	<div class="grid grid-3">
+		<ui-card variant="carousel vertical ar(4/3) fs(sm)" controls="dots arrows"
+			style="--ui-card-dot-bg: rgb(0 0 0 / 0.25); --ui-card-dot-active: var(--color-accent); --ui-card-dot-size: 0.8rem;">
+			<cq-box>
+				<ui-media><img src="assets/destinations.jpg" alt=""><img src="assets/river.jpg" alt=""><img src="assets/mindfulness.jpg" alt=""></ui-media>
+				<ui-content><small data-part="eyebrow">themed dots</small><h2 data-part="headline">Bigger accent dots</h2></ui-content>
+			</cq-box>
+		</ui-card>
+		<ui-card class="svg-arrows" variant="carousel vertical ar(4/3) fs(sm)" controls="dots arrows"
+			style="--ui-card-arrow-bg: var(--color-accent); --ui-card-arrow-bg-hover: var(--color-accent); --ui-card-dot-active: var(--color-accent);">
+			<cq-box>
+				<ui-media><img src="assets/hubble.jpg" alt=""><img src="assets/quantum.jpg" alt=""><img src="assets/websummit.jpg" alt=""></ui-media>
+				<ui-content><small data-part="eyebrow">themed arrows</small><h2 data-part="headline">SVG chevrons via <code>url()</code></h2></ui-content>
+			</cq-box>
+		</ui-card>
+		<ui-card variant="carousel vertical ar(4/3) fs(sm)" controls="arrows"
+			style="--ui-card-arrow-radius: var(--radius-md, 0.5rem); --ui-card-arrow-size: 2.5rem; --ui-card-arrow-bg: rgb(0 0 0 / 0.6); --ui-card-arrow-bg-hover: rgb(0 0 0 / 0.85);">
+			<cq-box>
+				<ui-media><img src="assets/gastronomy.jpg" alt=""><img src="assets/brewandbean.jpg" alt=""><img src="assets/aurasoundpro.jpg" alt=""></ui-media>
+				<ui-content><small data-part="eyebrow">squared arrows</small><h2 data-part="headline">Bigger, rounded-rect buttons</h2></ui-content>
+			</cq-box>
+		</ui-card>
+	</div>
+
+	<!-- cursor-tracked hover needs a tiny pointer handler -->
+	<script type="module">
+		// hv(track): the only media effect that needs JS — map the pointer to
+		// --ui-card-mx / --ui-card-my (-1..1), which the CSS reads to translate the image.
+		for (const card of document.querySelectorAll('.track')) {
+			card.addEventListener('pointermove', (e) => {
+				const r = card.getBoundingClientRect();
+				card.style.setProperty('--ui-card-mx', ((e.clientX - r.left) / r.width * 2 - 1).toFixed(3));
+				card.style.setProperty('--ui-card-my', ((e.clientY - r.top) / r.height * 2 - 1).toFixed(3));
+			});
+			card.addEventListener('pointerleave', () => {
+				card.style.removeProperty('--ui-card-mx');
+				card.style.removeProperty('--ui-card-my');
+			});
+		}
+	</script>
+</body>
+</html>

--- a/ui/card/readme.md
+++ b/ui/card/readme.md
@@ -459,6 +459,16 @@ switching (`variant-lg`), the `fs(xl)` hero, scrim overlay cards, the three
 themes, and profile/product cards — with realistic content and images under
 `assets/`.
 
+Two focused demos break the tokens out by structural element:
+
+- **[`media.html`](media.html)** — every `<ui-media>` token: `ar()`
+  aspect-ratios, `op()` object-position, `fl()` flip, `hv()` hover effects, the
+  `sc()` scrim, ribbon/badge overlays, `<video>` and the `carousel` (controls
+  and theming).
+- **[`content.html`](content.html)** — every `<ui-content>` token: the `fs()`
+  typographic scale, `th()` themes, the content parts, `p()` padding, `sp()`
+  splits, `sq()` corners, scrollable content and the core surface tokens.
+
 ## Notes
 
 - **CSS-only.** No web component ships in this version — add `<cq-box>` by hand.


### PR DESCRIPTION
## Summary

Adds two focused demo pages under `ui/card/`, splitting the `<ui-card>` token showcase by its two structural elements — `<ui-media>` and `<ui-content>` — alongside the existing end-to-end `index.html`.

### `media.html` — every `<ui-media>` token
- **`ar()`** — all eight aspect-ratios (`1/1 … 21/9`), same image so only the crop changes
- **`op()`** — all nine object-position codes (`tl … br`) on one square frame
- **`--ui-card-object-fit`** — `cover` / `contain` / `fill`
- **`fl()`** — `h` / `v` / `hv` flip vs. original
- **`hv()`** — `zoom`, `pan`, `track`, `lift`, `shrink`, `tilt` (with a tiny pointer handler for the cursor-tracked `track`, the one effect that needs JS)
- **`sc()` scrim** — `ov()` placement + auto-matched/explicit scrim and custom colour
- **ribbon & badge** — `pos()`, `color`, and the four diagonal corners
- **`<video>`** — controls + autoplay variants
- **`carousel`** — default dots+arrows, the `controls` attribute (`dots` / `arrows` / both / `none`), and theming (dot/arrow tokens, SVG chevrons, squared buttons)

### `content.html` — every `<ui-content>` token
- **`fs()`** — the decoupled body + headline scale at `sm/md/lg/xl`, plus a wide card showing the headline ramp pushing hard while the body stays readable
- **content parts** — full anatomy: eyebrow, headline, subheadline, summary, byline, meta, caption, tags, actions, footer
- **`th()`** — default, `subtle`, `dark`, `brand`
- **`p()` padding** and **`--ui-card-row-gap`**
- **arrangement + `sp()`** — `horizontal` / `horizontal-r` with column splits
- **`ov()`** overlay placement
- **`sq()`** squircle corners (`sm … xl`)
- **`[scroll]`** scrollable content with the CSS fade-shadow
- **core surface tokens** — `--ui-card-bg` / `--ui-card-radius` / `--ui-card-shadow`

Both pages reuse the existing demo conventions (the `.grid` helpers, `.note` copy, the `.svg-arrows` token override) and the local images under `assets/`. `readme.md`'s Demo section now links both.

## Notes
- Pure CSS except the documented `hv(track)` pointer handler.
- Carousel controls and `sq()` are Chromium-only and degrade gracefully, as in the main demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FJM5eQR7RAi1RjGCepVrjJ)_