### PR TITLE
Rework card furniture into a unified, preset-driven model

### DIFF
--- a/cms/baseline/models/card-preset.schema.json
+++ b/cms/baseline/models/card-preset.schema.json
@@ -97,7 +97,7 @@
     "media": {
       "type": "string",
       "title": "media=",
-      "description": "Media frame tokens: asr(16/9 …), obf(), obp(), hov(), scm, nav(), auto, loop, clip … Furniture tokens (chip/sticker/save/play positions) are appended by the renderer from card content — do not put them here.",
+      "description": "Media frame tokens: asr(16/9 …), obf(), obp(), hov(), scm, nav(), auto, loop, clip … Furniture styling also lives here, as single-value tokens (the CSS matches them by substring, so combine one value per token, not chip(ts red)): position chip|sticker|save|play(ts…be); hue chip|sticker|save(red|orange|green|blue|accent|dark|light|subtle); sticker shape sticker(burst|spark|sunburst|heart|blob|text|spl|spr); save size save(sm|lg|xl) and disc save(crc|sqr|rnd|non); play size play(sm|lg|xl). The renderer emits the furniture elements from the card's content.furniture object and appends each item's optional style= override after these tokens (a same-axis override replaces the preset's token).",
       "localized": false
     },
     "content": {

--- a/cms/baseline/models/card.schema.json
+++ b/cms/baseline/models/card.schema.json
@@ -35,7 +35,7 @@
         "name": "Media",
         "description": "Media items (more than one becomes a carousel) and overlay furniture",
         "collapse": true,
-        "fields": ["media", "chip", "sticker", "play", "saveable"]
+        "fields": ["media", "furniture"]
       },
       {
         "area": "main",
@@ -301,153 +301,125 @@
         }
       }
     },
-    "chip": {
+    "furniture": {
       "type": "object",
-      "title": "Chip",
-      "description": "Small label overlaid on the media (<ui-chip>) — replaces the legacy ribbon",
+      "title": "Furniture",
+      "description": "Overlay elements placed on top of the media area: a chip label, a sticker callout, a save/favorite toggle and a play affordance. This model carries only their TEXT/semantic content — position, hue, size and shape are set in the preset's media= token string (chip/sticker/save/play tokens), optionally overridden per item via 'style'.",
       "properties": {
-        "text": {
-          "type": "string",
-          "title": "Text"
+        "chip": {
+          "type": "object",
+          "title": "Chip",
+          "description": "Small pill label overlaid on the media (<ui-chip>) — replaces the legacy ribbon.",
+          "properties": {
+            "text": {
+              "type": "string",
+              "title": "Text"
+            },
+            "badge": {
+              "type": "string",
+              "title": "Badge",
+              "description": "Optional count/label rendered as a nested <ui-badge> (e.g. \"4\")."
+            },
+            "style": {
+              "type": "string",
+              "title": "Style override",
+              "localized": false,
+              "description": "Extra chip() tokens appended after the preset, e.g. \"red\" or \"bs red\". Overrides the preset for the same axis (position/hue)."
+            }
+          }
         },
-        "position": {
-          "type": "select",
-          "title": "Position",
-          "localized": false,
-          "default": "ts",
-          "options": [
-            { "value": "ts", "label": "Top start" },
-            { "value": "tc", "label": "Top center" },
-            { "value": "te", "label": "Top end" },
-            { "value": "cs", "label": "Center start" },
-            { "value": "cc", "label": "Center" },
-            { "value": "ce", "label": "Center end" },
-            { "value": "bs", "label": "Bottom start" },
-            { "value": "bc", "label": "Bottom center" },
-            { "value": "be", "label": "Bottom end" }
-          ]
+        "sticker": {
+          "type": "object",
+          "title": "Sticker",
+          "description": "Callout disc/shape overlaid on the media (<ui-sticker>). Its multi-line typography is authored as 'lines' — each line renders as its own element and is styled by the sticker's font= / font-lead= tokens.",
+          "properties": {
+            "lines": {
+              "type": "array",
+              "title": "Lines",
+              "description": "One entry per typographic line. 'label' → <small> (font=), 'lead' → <strong> (font-lead=), 'plain' → <span> (fluid). Optional 'sup' renders a trailing <sup> (e.g. price cents).",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "role": {
+                    "type": "select",
+                    "title": "Role",
+                    "localized": false,
+                    "default": "label",
+                    "options": [
+                      { "value": "label", "label": "Label (<small>)" },
+                      { "value": "lead", "label": "Lead (<strong>)" },
+                      { "value": "plain", "label": "Plain (<span>)" }
+                    ]
+                  },
+                  "text": {
+                    "type": "string",
+                    "title": "Text"
+                  },
+                  "sup": {
+                    "type": "string",
+                    "title": "Superscript",
+                    "description": "Optional <sup> appended after the text, e.g. price cents."
+                  }
+                }
+              }
+            },
+            "style": {
+              "type": "string",
+              "title": "Style override",
+              "localized": false,
+              "description": "Extra sticker() tokens appended after the preset, e.g. \"burst red\" or \"te heart\". Overrides the preset for the same axis (position/hue/shape)."
+            }
+          }
         },
-        "hue": {
-          "type": "select",
-          "title": "Hue",
-          "localized": false,
-          "options": [
-            { "value": "red", "label": "Red" },
-            { "value": "orange", "label": "Orange" },
-            { "value": "green", "label": "Green" },
-            { "value": "blue", "label": "Blue" },
-            { "value": "accent", "label": "Accent" },
-            { "value": "dark", "label": "Dark" },
-            { "value": "light", "label": "Light" },
-            { "value": "subtle", "label": "Subtle" }
-          ]
+        "save": {
+          "type": "object",
+          "title": "Save",
+          "description": "Save/favorite toggle overlaid on the media (<ui-save>). The boolean value true is also accepted and defaults to a heart.",
+          "properties": {
+            "shape": {
+              "type": "select",
+              "title": "Shape",
+              "localized": false,
+              "default": "heart",
+              "options": [
+                { "value": "heart", "label": "Heart" },
+                { "value": "bookmark", "label": "Bookmark" },
+                { "value": "star", "label": "Star" }
+              ]
+            },
+            "saved": {
+              "type": "boolean",
+              "title": "Saved",
+              "description": "Initial saved state (button aria-pressed).",
+              "default": false
+            },
+            "style": {
+              "type": "string",
+              "title": "Style override",
+              "localized": false,
+              "description": "Extra save() tokens appended after the preset, e.g. \"orange sm\" or \"non\" (hide the disc)."
+            }
+          }
+        },
+        "play": {
+          "type": "object",
+          "title": "Play",
+          "description": "Play/pause affordance overlaid on the media (<ui-play>) — for videos and autoplay carousels, where it becomes the sole play/pause control. The boolean value true is also accepted.",
+          "properties": {
+            "label": {
+              "type": "string",
+              "title": "Aria label",
+              "default": "Play"
+            },
+            "style": {
+              "type": "string",
+              "title": "Style override",
+              "localized": false,
+              "description": "Extra play() tokens appended after the preset, e.g. \"lg\" or \"bs\"."
+            }
+          }
         }
       }
-    },
-    "sticker": {
-      "type": "object",
-      "title": "Sticker",
-      "description": "Callout disc overlaid on the media (<ui-sticker>)",
-      "properties": {
-        "text": {
-          "type": "string",
-          "title": "Text"
-        },
-        "position": {
-          "type": "select",
-          "title": "Position",
-          "localized": false,
-          "default": "te",
-          "options": [
-            { "value": "ts", "label": "Top start" },
-            { "value": "tc", "label": "Top center" },
-            { "value": "te", "label": "Top end" },
-            { "value": "cs", "label": "Center start" },
-            { "value": "cc", "label": "Center" },
-            { "value": "ce", "label": "Center end" },
-            { "value": "bs", "label": "Bottom start" },
-            { "value": "bc", "label": "Bottom center" },
-            { "value": "be", "label": "Bottom end" }
-          ]
-        },
-        "hue": {
-          "type": "select",
-          "title": "Hue",
-          "localized": false,
-          "options": [
-            { "value": "red", "label": "Red" },
-            { "value": "orange", "label": "Orange" },
-            { "value": "green", "label": "Green" },
-            { "value": "blue", "label": "Blue" },
-            { "value": "accent", "label": "Accent" },
-            { "value": "dark", "label": "Dark" },
-            { "value": "light", "label": "Light" },
-            { "value": "subtle", "label": "Subtle" }
-          ]
-        },
-        "burst": {
-          "type": "boolean",
-          "title": "Burst",
-          "description": "Use the burst shape (variant=\"burst\") instead of a plain disc",
-          "default": false
-        }
-      }
-    },
-    "play": {
-      "type": "object",
-      "title": "Play",
-      "description": "Play/pause affordance (<ui-play>) on the media — for videos and autoplay carousels. In autoplay/loop carousels it becomes the sole play/pause control.",
-      "properties": {
-        "position": {
-          "type": "select",
-          "title": "Position",
-          "localized": false,
-          "default": "cc",
-          "options": [
-            { "value": "ts", "label": "Top start" },
-            { "value": "tc", "label": "Top center" },
-            { "value": "te", "label": "Top end" },
-            { "value": "cs", "label": "Center start" },
-            { "value": "cc", "label": "Center" },
-            { "value": "ce", "label": "Center end" },
-            { "value": "bs", "label": "Bottom start" },
-            { "value": "bc", "label": "Bottom center" },
-            { "value": "be", "label": "Bottom end" }
-          ]
-        },
-        "hue": {
-          "type": "select",
-          "title": "Hue",
-          "localized": false,
-          "options": [
-            { "value": "red", "label": "Red" },
-            { "value": "orange", "label": "Orange" },
-            { "value": "green", "label": "Green" },
-            { "value": "blue", "label": "Blue" },
-            { "value": "accent", "label": "Accent" },
-            { "value": "dark", "label": "Dark" },
-            { "value": "light", "label": "Light" },
-            { "value": "subtle", "label": "Subtle" }
-          ]
-        },
-        "size": {
-          "type": "select",
-          "title": "Size",
-          "localized": false,
-          "options": [
-            { "value": "sm", "label": "Small" },
-            { "value": "md", "label": "Medium" },
-            { "value": "lg", "label": "Large" },
-            { "value": "xl", "label": "Extra large" }
-          ]
-        }
-      }
-    },
-    "saveable": {
-      "type": "boolean",
-      "title": "Saveable",
-      "description": "Show a save/favorite toggle (<ui-save>) on the media",
-      "default": false
     },
     "engagement": {
       "type": "object",

--- a/ui/card/card.md
+++ b/ui/card/card.md
@@ -68,10 +68,7 @@ lives in one `details` object discriminated by `schemaType`.
 | `tags` | tags | → pill list |
 | `actions` | array | `{link, style}` → `data-part="actions"` buttons. In an `ovr()` overlay card a plain solid button (`.ui-button` with no `data-variant`) is given **dark** text by `ui-card.css` so it stays legible on its light surface instead of inheriting the overlay's white ink; colour variants (accent, text, …) set their own ink and are left untouched |
 | `links` | array of link | Plain related links |
-| `chip` | object | `{text, position, hue}` → `<ui-chip>` (legacy ribbon) |
-| `sticker` | object | `{text, position, hue, burst}` → `<ui-sticker>` |
-| `play` | object | `{position, hue, size}` → `<ui-play>` button (videos, autoplay carousels) |
-| `saveable` | boolean \| object | → `<ui-save>` toggle. Object form `{shape, position, color, circle, saved}` — the renderer emits `<ui-icon shape=…>` and appends the `save(…)` media tokens. See **Save furniture** below |
+| `furniture` | object | Overlay elements on the media — `{chip, sticker, save, play}`. **Content only** (text/semantics); the *look* (position, hue, size, shape) lives in the preset's `media=` tokens. See **Furniture** below |
 | `engagement` | object | counts → `InteractionCounter` microdata |
 | `details` | object | Type-specific payload (`ui.widget: editor-card`) |
 | `flipside` | reference → `card` | Optional custom reveal back panel — see below |
@@ -108,52 +105,68 @@ Documented in full in the model's `details` description. Examples:
 Machine values stay schema-ready (`PT15M`, salary numbers, geo coordinates);
 `*Display` keys carry pre-formatted strings only where formatting is not derivable.
 
-## Save furniture — `<ui-save>`
+## Furniture — chip · sticker · save · play
 
-A save / favorite / bookmark toggle, placed over the media (Amazon / IMDb style). It
-composes an **invoker button** and a **`<ui-icon type="shape">`**:
+The four overlay elements (`<ui-chip>`, `<ui-sticker>`, `<ui-save>`, `<ui-play>`) share
+one rule: **content decides *what* and *whether*; the preset decides *how it looks*.** The
+content model carries a single `furniture` object holding only text/semantics; the preset's
+`media=` token string carries position, hue, size and shape. The renderer emits the elements
+from `furniture` and *never* generates position/hue tokens — they come from the preset (the
+hand-authored [`media.furniture.html`](media.furniture.html) is the reference shape).
 
-```html
-<ui-media>
-  <img …>
-  <ui-save>
-    <button type="button" command="--save" commandfor="<card-or-media id>" aria-label="Save">
-      <ui-icon type="shape" shape="heart" variant="outline"></ui-icon>
-    </button>
-  </ui-save>
-</ui-media>
+```jsonc
+// content — text/semantics only
+"furniture": {
+  "chip":    { "text": "Breaking", "badge": "4", "style": "ts red" },
+  "sticker": { "lines": [ {"role":"label","text":"SAVE"}, {"role":"lead","text":"20","sup":"%"} ] },
+  "save":    { "shape": "heart", "saved": false },
+  "play":    true
+}
+```
+```jsonc
+// preset — look (media= tokens)
+"media": "asr(4/3) sticker(te) sticker(burst) sticker(green) save(be) play(cc)"
 ```
 
-**Shape is content, not a token.** Like `<ui-chip>` text or `ui-play`'s `type=`, the glyph is
-authored on the child `<ui-icon>` (`shape="heart|bookmark|star"`, `variant="outline"`). The
-renderer reads `saveable.shape` and emits that `<ui-icon shape=…>` directly — `media=` never
-carries the shape.
-
-**`media=` carries position, colour and the disc** (parsed like `chip()`/`sticker()`):
+**Look tokens on `media=`** — single-value tokens (the CSS matches them by substring, so
+one value per token, never `chip(ts red)`). The vocabulary is shared across all four:
 
 | Token | Effect |
 |-------|--------|
-| `save(<pos>)` | Position on the 9-code grid — `ts tc te · cs cc ce · bs bc be` (default `te`) |
-| `save(<hue>)` | Ink (idle + saved) from the 8 theme hues — `red orange green blue accent dark light subtle`. Same vocabulary for `chip()`/`sticker()`/`play()` |
-| `save(<size>)` | Scale — `sm lg xl` (`md` = default) |
-| `save(<corner>)` | Disc shape — `crc` circle (default) · `sqr` squircle · `rnd` rounded. `save(non)` hides the disc |
+| `el(<pos>)` | Position on the 9-code grid — `ts tc te · cs cc ce · bs bc be` |
+| `el(<hue>)` | Colour from the 8 theme hues — `red orange green blue accent dark light subtle` |
+| `el(<size>)` | Scale — `sm lg xl` (`md` = default); `play`/`save` |
+| `sticker(<shape>)` | `burst spark sunburst heart blob text spl spr` — no `variant=` needed |
+| `save(<corner>)` | Disc — `crc` circle (default) · `sqr` squircle · `rnd` rounded · `non` hides the disc |
 
-The disc is a solid **circle** by default (`--ui-save-circle-bg` = `Canvas`); it keeps the glyph
-legible over busy images. `bookmark` defaults to the accent colour without a `save(<hue>)` token.
+where `el` is `chip` / `sticker` / `save` / `play`. Each also works standalone via `theme=` /
+`fill=` / `ink=` / `size=` / `radius=` on the element itself.
 
-**All furniture shares one colour / size / corner model** — `el(<hue>)` · `el(<size>)` ·
-`el(<corner>)` from `media=`, or `theme=` / `fill=` / `ink=` / `size=` / `radius=` standalone. The
-corner values `non rnd pll crc sqr` are the same 3-letter set as the card frame's `rds()`
-(`rds(non/crc/pll/sm…xl/*-sqr)`; the legacy `none/full/pill/-sq` spellings still work as aliases).
+**Per-card override — `style`.** Furniture styling defaults to the preset, but any item may
+carry an optional `style` token string (same vocabulary) that the renderer appends after the
+preset tokens. A same-axis override *replaces* the preset's token for that axis
+(`mergeMediaTokens` strips the collision so the override wins deterministically — the CSS
+resolves `media=` matches by source-order, not token-order). So one card can go
+`chip: { text: "Breaking", style: "red" }` while the shared preset stays green.
 
-**State & interactivity.** The look is pure CSS off the button's `aria-pressed` — unsaved = outline
-+ idle ink, saved = filled + active ink. The toggle itself is script: `command="--save"` is a
-custom invoker whose `commandfor` points at the **`<ui-card>` or `<ui-media>`** (set by the
-renderer) so the handler has the card in hand. The `command` event does **not** bubble — listen on
-the target:
+**Text models.**
+- **chip** — a plain `text` label, plus an optional `badge` → nested `<ui-badge>`.
+- **sticker** — `lines[]`, one entry per typographic line: `role: "label"` → `<small>`
+  (styled by `font=`), `"lead"` → `<strong>` (styled by `font-lead=`), `"plain"` → `<span>`
+  (fluid). Optional `sup` renders a trailing `<sup>` (price cents, etc.). This structured shape
+  replaces the old flat `sticker.text`, which could only ever emit one `<strong>` line.
+- **save / play** — no text; both accept a bare `true`. `save` takes `{shape, saved}` (the
+  glyph `heart|bookmark|star` is content, authored on the emitted `<ui-icon shape=…>` — never a
+  `media=` token; `saved` sets initial `aria-pressed`). `play` takes an optional `label`.
+
+**Save state & interactivity.** The look is pure CSS off the button's `aria-pressed` — unsaved =
+outline + idle ink, saved = filled + active ink. The toggle is script: `command="--save"` is a
+custom invoker whose `commandfor` the renderer points at the `<ui-media>` (id `<card-id>-media`)
+so the handler has the frame in hand. The `command` event does **not** bubble — listen on the
+target:
 
 ```js
-card.addEventListener('command', (e) => {
+media.addEventListener('command', (e) => {
   if (e.command !== '--save') return;
   const btn = e.source;
   const saved = btn.getAttribute('aria-pressed') !== 'true';
@@ -162,8 +175,9 @@ card.addEventListener('command', (e) => {
 });
 ```
 
-Classified as a **control** (interactive) — card-only, never inside a reveal `<summary>`. Demos in
-[`media.furniture.html`](media.furniture.html); full component: [`ui/save`](../save/).
+Save/play are **controls** (interactive) — card-only, never inside a reveal `<summary>`. Demos in
+[`media.furniture.html`](media.furniture.html); components: [`ui/chip`](../chip/) ·
+[`ui/sticker`](../sticker/) · [`ui/save`](../save/) · [`ui/play`](../play/).
 
 ## Preset model — `card-preset`
 
@@ -175,7 +189,7 @@ Classified as a **control** (interactive) — card-only, never inside a reveal `
 | `name`, `description` | both | e.g. “Hero Preset” |
 | `element` | both | `ui-card` (default), `ui-reveal` — or `ui-media` / `ui-content` for **bare primitives**: the renderer emits just the media frame or content column, no card chrome. Standalone blocks are presentation, not a separate content model |
 | `variant` | both | `col row row-r spl() ovr() vis() thm() rds()` |
-| `media` | both | `asr() obf() obp() flp() rds() shp() hov() tnt() scm nav() auto loop clip …` — furniture tokens are appended by the renderer from content |
+| `media` | both | `asr() obf() obp() flp() rds() shp() hov() tnt() scm nav() auto loop clip …` — plus the furniture look tokens (`chip/sticker/save/play` position/hue/size/shape). The renderer appends each furniture item's optional `style=` override after these |
 | `content` | both | `scl() pad() gap() scr` |
 | `text` | both | which long text the content column shows: `summary` (teaser — default), `body` (full view — body **instead of** summary, with the summary kept as a hidden `description` meta), `both`. Reveal back panels always render both |
 | `styles` | both | object of CSS custom properties → `style` attribute (e.g. `--ui-reveal-content-bg`) |
@@ -277,8 +291,9 @@ grid.insertAdjacentHTML('beforeend', renderCard(ucf, presets));
 | `loadPresets` | `(url) => Promise<object>` | fetch `card.presets.json` → id→preset map |
 | `SCHEMA_TYPES` | map | schemaType → schema.org type |
 
-Pipeline: resolve preset → build `<ui-media>` (items; furniture appended with
-matching `media=` position/hue tokens) → build `<ui-content>` envelope parts →
+Pipeline: resolve preset → build `<ui-media>` (items; furniture emitted from the
+`furniture` object, its look from the preset's `media=` tokens plus any `style=`
+overrides) → build `<ui-content>` envelope parts →
 run the per-type `DETAILS` renderer → append trailers (byline, tags, actions,
 engagement). `preset.element === "ui-reveal"` switches to the reveal composition
 (front `<ui-face>`, back panel). Unknown preset refs fall back to a plain stack

--- a/ui/card/data/achievement.json
+++ b/ui/card/data/achievement.json
@@ -25,11 +25,13 @@
         "alt": "Deep space photograph"
       }
     ],
-    "sticker": {
-      "text": "Certified",
-      "position": "te",
-      "hue": "green",
-      "burst": true
+    "furniture": {
+      "sticker": {
+        "lines": [
+          { "role": "lead", "text": "Certified" }
+        ],
+        "style": "te green burst"
+      }
     },
     "actions": [
       {

--- a/ui/card/data/card.presets.demo.json
+++ b/ui/card/data/card.presets.demo.json
@@ -7,7 +7,7 @@
       "name": "Media Aspect 1:1",
       "description": "Standalone <ui-media> frame, square crop",
       "element": "ui-media",
-      "media": "asr(1/1)"
+      "media": "asr(1/1) chip(bs)"
     },
     "media-asr-6x7": {
       "name": "Media Aspect 6:7",
@@ -55,7 +55,7 @@
       "name": "Media Corners Small",
       "description": "Standalone <ui-media> frame, 4:3, small radius",
       "element": "ui-media",
-      "media": "asr(4/3) rds(sm)"
+      "media": "asr(4/3) rds(sm) chip(bs)"
     },
     "media-rds-lg": {
       "name": "Media Corners Large",
@@ -80,7 +80,7 @@
       "description": "Media-only square card, object-position top left",
       "element": "ui-card",
       "variant": "vis(media)",
-      "media": "asr(1/1) obp(tl)"
+      "media": "asr(1/1) obp(tl) chip(tc)"
     },
     "media-obp-tc": {
       "name": "Media Position Top Center",
@@ -311,10 +311,10 @@
     },
     "carousel-plain": {
       "name": "Carousel Plain",
-      "description": "Bare swipe scroller — nav(non); chip furniture comes from content",
+      "description": "Bare swipe scroller — nav(non); chip text comes from content, chip(te) placement from the preset",
       "element": "ui-card",
       "variant": "col",
-      "media": "asr(4/3) nav(non)",
+      "media": "asr(4/3) nav(non) chip(te)",
       "content": "scl(sm)"
     },
     "carousel-dots-themed": {
@@ -648,18 +648,18 @@
     },
     "carousel-play": {
       "name": "Carousel Play",
-      "description": "Autoplay 4s + loop + pill timer; pinned <ui-play> control comes from content",
+      "description": "Autoplay 4s + loop + pill timer; the <ui-play> control's placement/size come from the preset, its presence from content",
       "element": "ui-card",
       "variant": "col",
-      "media": "asr(4/3) nav dot(pll) auto(4s) loop",
+      "media": "asr(4/3) nav dot(pll) auto(4s) loop play(bs) play(sm)",
       "content": "scl(sm)"
     },
     "carousel-play-end": {
       "name": "Carousel Play End",
-      "description": "Autoplay 4s + loop; <ui-play> pinned bottom-right from content",
+      "description": "Autoplay 4s + loop; <ui-play> pinned bottom-right, placement/size from the preset",
       "element": "ui-card",
       "variant": "col",
-      "media": "asr(4/3) nav auto(4s) loop",
+      "media": "asr(4/3) nav auto(4s) loop play(be) play(sm)",
       "content": "scl(sm)"
     },
     "carousel-videos": {

--- a/ui/card/data/demo/carousel-04.json
+++ b/ui/card/data/demo/carousel-04.json
@@ -35,9 +35,10 @@
         "alt": "FitTrack Pro fitness watch"
       }
     ],
-    "chip": {
-      "text": "3 photos",
-      "position": "te"
+    "furniture": {
+      "chip": {
+        "text": "3 photos"
+      }
     }
   }
 }

--- a/ui/card/data/demo/carousel-09.json
+++ b/ui/card/data/demo/carousel-09.json
@@ -40,9 +40,8 @@
         "alt": "Plated dish in a restaurant"
       }
     ],
-    "play": {
-      "position": "bs",
-      "size": "sm"
+    "furniture": {
+      "play": true
     }
   }
 }

--- a/ui/card/data/demo/carousel-10.json
+++ b/ui/card/data/demo/carousel-10.json
@@ -35,9 +35,8 @@
         "alt": "Conference stage at Web Summit"
       }
     ],
-    "play": {
-      "position": "be",
-      "size": "sm"
+    "furniture": {
+      "play": true
     }
   }
 }

--- a/ui/card/data/demo/media-01.json
+++ b/ui/card/data/demo/media-01.json
@@ -15,9 +15,10 @@
     "preset": {
       "$ref": "card-preset/media-asr-1x1"
     },
-    "chip": {
-      "text": "asr(1/1)",
-      "position": "bs"
+    "furniture": {
+      "chip": {
+        "text": "asr(1/1)"
+      }
     },
     "media": [
       {

--- a/ui/card/data/demo/media-02.json
+++ b/ui/card/data/demo/media-02.json
@@ -15,9 +15,10 @@
     "preset": {
       "$ref": "card-preset/media-rds-sm"
     },
-    "chip": {
-      "text": "rds(sm)",
-      "position": "bs"
+    "furniture": {
+      "chip": {
+        "text": "rds(sm)"
+      }
     },
     "media": [
       {

--- a/ui/card/data/demo/media-03.json
+++ b/ui/card/data/demo/media-03.json
@@ -15,9 +15,10 @@
     "preset": {
       "$ref": "card-preset/media-obp-tl"
     },
-    "chip": {
-      "text": "obp(tl)",
-      "position": "tc"
+    "furniture": {
+      "chip": {
+        "text": "obp(tl)"
+      }
     },
     "media": [
       {

--- a/ui/card/data/demo/media-04.json
+++ b/ui/card/data/demo/media-04.json
@@ -15,9 +15,11 @@
     "preset": {
       "$ref": "card-preset/media-vis-1x1"
     },
-    "chip": {
-      "text": "cover (default)",
-      "position": "bs"
+    "furniture": {
+      "chip": {
+        "text": "cover (default)",
+        "style": "bs"
+      }
     },
     "media": [
       {

--- a/ui/card/data/demo/media-05.json
+++ b/ui/card/data/demo/media-05.json
@@ -15,11 +15,16 @@
     "preset": {
       "$ref": "card-preset/media-vis-1x1"
     },
-    "sticker": {
-      "text": "ts",
-      "position": "ts",
-      "hue": "blue",
-      "burst": true
+    "furniture": {
+      "sticker": {
+        "lines": [
+          {
+            "role": "lead",
+            "text": "ts"
+          }
+        ],
+        "style": "ts blue burst"
+      }
     },
     "media": [
       {

--- a/ui/card/data/demo/media-16.json
+++ b/ui/card/data/demo/media-16.json
@@ -17,15 +17,20 @@
     },
     "eyebrow": "Audio",
     "headline": "Sticker + chip",
-    "sticker": {
-      "text": "Featured",
-      "position": "ts",
-      "hue": "red"
-    },
-    "chip": {
-      "text": "New",
-      "position": "be",
-      "hue": "green"
+    "furniture": {
+      "chip": {
+        "text": "New",
+        "style": "be green"
+      },
+      "sticker": {
+        "lines": [
+          {
+            "role": "lead",
+            "text": "Featured"
+          }
+        ],
+        "style": "ts red"
+      }
     },
     "media": [
       {

--- a/ui/card/data/demo/media-17.json
+++ b/ui/card/data/demo/media-17.json
@@ -17,11 +17,16 @@
     },
     "eyebrow": "Furniture",
     "headline": "Starburst sticker",
-    "sticker": {
-      "text": "-28%",
-      "position": "te",
-      "hue": "red",
-      "burst": true
+    "furniture": {
+      "sticker": {
+        "lines": [
+          {
+            "role": "lead",
+            "text": "-28%"
+          }
+        ],
+        "style": "te red burst"
+      }
     },
     "media": [
       {

--- a/ui/card/data/demo/media-18.json
+++ b/ui/card/data/demo/media-18.json
@@ -17,15 +17,20 @@
     },
     "eyebrow": "Café",
     "headline": "Accent chip + orange sticker",
-    "chip": {
-      "text": "Editor's pick",
-      "position": "bs",
-      "hue": "accent"
-    },
-    "sticker": {
-      "text": "Sale",
-      "position": "te",
-      "hue": "orange"
+    "furniture": {
+      "chip": {
+        "text": "Editor's pick",
+        "style": "bs accent"
+      },
+      "sticker": {
+        "lines": [
+          {
+            "role": "lead",
+            "text": "Sale"
+          }
+        ],
+        "style": "te orange"
+      }
     },
     "media": [
       {

--- a/ui/card/data/demo/video-01.json
+++ b/ui/card/data/demo/video-01.json
@@ -26,8 +26,10 @@
         "duration": "PT2M10S"
       }
     ],
-    "chip": {
-      "text": "native video"
+    "furniture": {
+      "chip": {
+        "text": "native video"
+      }
     }
   }
 }

--- a/ui/card/data/demo/video-02.json
+++ b/ui/card/data/demo/video-02.json
@@ -29,11 +29,13 @@
         "duration": "PT2M10S"
       }
     ],
-    "play": {
-      "position": "cc"
-    },
-    "chip": {
-      "text": "native custom"
+    "furniture": {
+      "chip": {
+        "text": "native custom"
+      },
+      "play": {
+        "style": "cc"
+      }
     }
   }
 }

--- a/ui/card/data/demo/video-03.json
+++ b/ui/card/data/demo/video-03.json
@@ -28,11 +28,13 @@
         "duration": "PT2M10S"
       }
     ],
-    "play": {
-      "position": "cc"
-    },
-    "chip": {
-      "text": "autoplay"
+    "furniture": {
+      "chip": {
+        "text": "autoplay"
+      },
+      "play": {
+        "style": "cc"
+      }
     }
   }
 }

--- a/ui/card/data/demo/video-04.json
+++ b/ui/card/data/demo/video-04.json
@@ -27,11 +27,13 @@
         "alt": "River video behind an unrelated poster image"
       }
     ],
-    "play": {
-      "position": "cc"
-    },
-    "chip": {
-      "text": "custom poster"
+    "furniture": {
+      "chip": {
+        "text": "custom poster"
+      },
+      "play": {
+        "style": "cc"
+      }
     }
   }
 }

--- a/ui/card/data/demo/video-05.json
+++ b/ui/card/data/demo/video-05.json
@@ -29,13 +29,14 @@
         "src": "VTCIStB6y8s"
       }
     ],
-    "play": {
-      "position": "cc",
-      "size": "lg"
-    },
-    "chip": {
-      "text": "youtube",
-      "hue": "red"
+    "furniture": {
+      "chip": {
+        "text": "youtube",
+        "style": "red"
+      },
+      "play": {
+        "style": "cc lg"
+      }
     }
   }
 }

--- a/ui/card/data/demo/video-06.json
+++ b/ui/card/data/demo/video-06.json
@@ -24,13 +24,14 @@
         "src": "5b4YcLB4DVI"
       }
     ],
-    "play": {
-      "position": "cc",
-      "size": "lg"
-    },
-    "chip": {
-      "text": "youtube",
-      "hue": "red"
+    "furniture": {
+      "chip": {
+        "text": "youtube",
+        "style": "red"
+      },
+      "play": {
+        "style": "cc lg"
+      }
     }
   }
 }

--- a/ui/card/data/demo/video-07.json
+++ b/ui/card/data/demo/video-07.json
@@ -29,13 +29,14 @@
         "src": "beYbnNT_02U"
       }
     ],
-    "play": {
-      "position": "cc",
-      "size": "lg"
-    },
-    "chip": {
-      "text": "youtube",
-      "hue": "red"
+    "furniture": {
+      "chip": {
+        "text": "youtube",
+        "style": "red"
+      },
+      "play": {
+        "style": "cc lg"
+      }
     }
   }
 }

--- a/ui/card/data/demo/video-08.json
+++ b/ui/card/data/demo/video-08.json
@@ -27,12 +27,13 @@
         "alt": "Museum trailer"
       }
     ],
-    "play": {
-      "position": "cc",
-      "size": "lg"
-    },
-    "chip": {
-      "text": "vimeo native"
+    "furniture": {
+      "chip": {
+        "text": "vimeo native"
+      },
+      "play": {
+        "style": "cc lg"
+      }
     },
     "actions": [
       {

--- a/ui/card/data/demo/video-09.json
+++ b/ui/card/data/demo/video-09.json
@@ -27,12 +27,13 @@
         "alt": "Autumn on the heath around the museum"
       }
     ],
-    "play": {
-      "position": "cc",
-      "size": "lg"
-    },
-    "chip": {
-      "text": "vimeo native"
+    "furniture": {
+      "chip": {
+        "text": "vimeo native"
+      },
+      "play": {
+        "style": "cc lg"
+      }
     },
     "actions": [
       {

--- a/ui/card/data/demo/video-10.json
+++ b/ui/card/data/demo/video-10.json
@@ -29,14 +29,14 @@
         "src": "845207657"
       }
     ],
-    "play": {
-      "position": "cc",
-      "size": "lg"
-    },
-    "chip": {
-      "text": "vimeo iframe",
-      "position": "ts",
-      "hue": "green"
+    "furniture": {
+      "chip": {
+        "text": "vimeo iframe",
+        "style": "ts green"
+      },
+      "play": {
+        "style": "cc lg"
+      }
     },
     "actions": [
       {

--- a/ui/card/data/demo/video-11.json
+++ b/ui/card/data/demo/video-11.json
@@ -29,12 +29,13 @@
         "src": "696120095"
       }
     ],
-    "play": {
-      "position": "cc",
-      "size": "lg"
-    },
-    "chip": {
-      "text": "vimeo iframe"
+    "furniture": {
+      "chip": {
+        "text": "vimeo iframe"
+      },
+      "play": {
+        "style": "cc lg"
+      }
     },
     "actions": [
       {

--- a/ui/card/data/demo/video-12.json
+++ b/ui/card/data/demo/video-12.json
@@ -24,12 +24,13 @@
         "src": "695669200"
       }
     ],
-    "play": {
-      "position": "cc",
-      "size": "xl"
-    },
-    "chip": {
-      "text": "vimeo iframe"
+    "furniture": {
+      "chip": {
+        "text": "vimeo iframe"
+      },
+      "play": {
+        "style": "cc xl"
+      }
     }
   }
 }

--- a/ui/card/data/demo/video-13.json
+++ b/ui/card/data/demo/video-13.json
@@ -26,12 +26,14 @@
         "src": "746542514"
       }
     ],
-    "play": {
-      "position": "cc"
-    },
-    "chip": {
-      "text": "vimeo iframe",
-      "position": "bs"
+    "furniture": {
+      "chip": {
+        "text": "vimeo iframe",
+        "style": "bs"
+      },
+      "play": {
+        "style": "cc"
+      }
     }
   }
 }

--- a/ui/card/data/demo/video-14.json
+++ b/ui/card/data/demo/video-14.json
@@ -26,11 +26,13 @@
         "src": "794832552"
       }
     ],
-    "play": {
-      "position": "cc"
-    },
-    "chip": {
-      "text": "vimeo iframe"
+    "furniture": {
+      "chip": {
+        "text": "vimeo iframe"
+      },
+      "play": {
+        "style": "cc"
+      }
     }
   }
 }

--- a/ui/card/data/demo/video-15.json
+++ b/ui/card/data/demo/video-15.json
@@ -26,13 +26,14 @@
         "src": "789027225"
       }
     ],
-    "play": {
-      "position": "cc"
-    },
-    "chip": {
-      "text": "vimeo iframe",
-      "position": "bs",
-      "hue": "dark"
+    "furniture": {
+      "chip": {
+        "text": "vimeo iframe",
+        "style": "bs dark"
+      },
+      "play": {
+        "style": "cc"
+      }
     }
   }
 }

--- a/ui/card/data/media-block.json
+++ b/ui/card/data/media-block.json
@@ -24,10 +24,11 @@
         "caption": "Copenhagen, blue hour"
       }
     ],
-    "chip": {
-      "text": "Featured",
-      "position": "ts",
-      "hue": "dark"
+    "furniture": {
+      "chip": {
+        "text": "Featured",
+        "style": "ts dark"
+      }
     }
   }
 }

--- a/ui/card/data/news.json
+++ b/ui/card/data/news.json
@@ -34,10 +34,11 @@
         "role": "Newsroom"
       }
     ],
-    "chip": {
-      "text": "Breaking",
-      "position": "ts",
-      "hue": "red"
+    "furniture": {
+      "chip": {
+        "text": "Breaking",
+        "style": "ts red"
+      }
     },
     "body": {
       "$richtext": true,

--- a/ui/card/data/product.json
+++ b/ui/card/data/product.json
@@ -25,13 +25,18 @@
         "alt": "AuraSound Pro wireless headphones"
       }
     ],
-    "sticker": {
-      "text": "-20%",
-      "position": "te",
-      "hue": "red",
-      "burst": true
+    "furniture": {
+      "sticker": {
+        "lines": [
+          { "role": "lead", "text": "-20%" }
+        ],
+        "style": "te red burst"
+      },
+      "save": {
+        "shape": "heart",
+        "style": "ts"
+      }
     },
-    "saveable": true,
     "actions": [
       {
         "link": {

--- a/ui/card/render.js
+++ b/ui/card/render.js
@@ -187,13 +187,95 @@ const embedVideoObject = (item) => {
 
 /* ── media column ── */
 
+/* ── overlay furniture (chip / sticker / save / play) ──
+   Content = the furniture object (text/semantics only). Look = the preset's
+   media= tokens; each item's optional style= override is appended and, for a
+   token that collides with the preset on the same axis, replaces it (the CSS
+   matches media= tokens by substring, so precedence is source-order, not token
+   order — mergeMediaTokens strips the preset's same-axis token so the override
+   always wins). */
+
+const FURNITURE_AXIS = {
+	pos: new Set(['ts', 'tc', 'te', 'cs', 'cc', 'ce', 'bs', 'bc', 'be']),
+	hue: new Set(['red', 'orange', 'green', 'blue', 'accent', 'dark', 'light', 'subtle']),
+	size: new Set(['sm', 'md', 'lg', 'xl']),
+	shape: new Set(['burst', 'spark', 'sunburst', 'heart', 'blob', 'text', 'spl', 'spr']),
+	disc: new Set(['crc', 'sqr', 'rnd', 'pll', 'non'])
+};
+const axisOf = (value) => {
+	for (const [axis, set] of Object.entries(FURNITURE_AXIS)) if (set.has(value)) return axis;
+	return value; /* unknown → exact-match replacement */
+};
+const FURNITURE_TOKEN = /^(chip|sticker|save|play)\(([^)]*)\)$/;
+
+/* Merge a preset media= string with furniture style-override tokens. Overrides
+   win: any preset token of the same element+axis is dropped before appending. */
+const mergeMediaTokens = (presetMedia, overrides = []) => {
+	const ov = overrides.filter(Boolean);
+	const base = String(presetMedia || '').split(/\s+/).filter(Boolean);
+	if (!ov.length) return base.join(' ');
+	const conflicts = new Set();
+	for (const token of ov) {
+		const match = FURNITURE_TOKEN.exec(token);
+		if (match) conflicts.add(`${match[1]}:${axisOf(match[2])}`);
+	}
+	const kept = base.filter((token) => {
+		const match = FURNITURE_TOKEN.exec(token);
+		return !match || !conflicts.has(`${match[1]}:${axisOf(match[2])}`);
+	});
+	return [...kept, ...ov].join(' ');
+};
+
+/* A furniture item's style= string → per-value tokens, e.g. ("chip", "bs red")
+   → ["chip(bs)", "chip(red)"]. Single-value tokens only (CSS matches by substring). */
+const styleTokens = (el, style) =>
+	String(style || '').split(/\s+/).filter(Boolean).map((token) => `${el}(${token})`);
+
+/* Build the overlay furniture markup from the unified furniture object and push
+   each item's style-override tokens onto tokens.media (positioning/hue/shape come
+   from the preset — the renderer no longer generates those). save/play also
+   accept a bare `true`. */
+const buildFurniture = (furniture, fields, tokens, mediaId) => {
+	if (!furniture) return '';
+	let html = '';
+	const push = (el, style) => { for (const token of styleTokens(el, style)) tokens.media.push(token); };
+
+	if (furniture.play) {
+		const play = furniture.play === true ? {} : furniture.play;
+		html += `<ui-play><button type="button" aria-label="${esc(play.label || 'Play')}" command="--toggle-play"><ui-icon type="play-pause"></ui-icon></button></ui-play>`;
+		push('play', play.style);
+	}
+	if (furniture.chip?.text) {
+		const chip = furniture.chip;
+		html += `<ui-chip>${esc(chip.text)}${chip.badge ? `<ui-badge>${esc(chip.badge)}</ui-badge>` : ''}</ui-chip>`;
+		push('chip', chip.style);
+	}
+	if (furniture.sticker?.lines?.length) {
+		const sticker = furniture.sticker;
+		const lines = sticker.lines.map((line) => {
+			const el = { label: 'small', lead: 'strong', plain: 'span' }[line.role] || 'small';
+			return `<${el}>${esc(line.text ?? '')}${line.sup ? `<sup>${esc(line.sup)}</sup>` : ''}</${el}>`;
+		}).join('');
+		html += `<ui-sticker>${lines}</ui-sticker>`;
+		push('sticker', sticker.style);
+	}
+	if (furniture.save) {
+		const save = furniture.save === true ? {} : furniture.save;
+		const name = esc(plain(fields.headline) || 'card');
+		const label = save.saved ? `Remove ${name} from favorites` : `Save ${name} to favorites`;
+		html += `<ui-save><button type="button" command="--save"${mediaId ? ` commandfor="${esc(mediaId)}"` : ''} aria-label="${label}"${save.saved ? ' aria-pressed="true"' : ''}><ui-icon type="shape" shape="${esc(save.shape || 'heart')}" variant="outline"></ui-icon></button></ui-save>`;
+		push('save', save.style);
+	}
+	return html;
+};
+
 /**
  * Build the <ui-media> string. Returns { html, hostAttrs, extras }:
  * - hostAttrs: attributes computed for the frame (provider embeds, dual-attribute carousel form)
  * - extras: schema markup that must live OUTSIDE ui-media (VideoObject for embeds → content column)
- * Furniture position/hue tokens are pushed onto tokens.media for the host's media= string.
+ * Furniture style-override tokens are pushed onto tokens.media for the host's media= string.
  */
-const buildMedia = (fields, type, tokens, preset = {}, frameAttrs = {}) => {
+const buildMedia = (fields, type, tokens, preset = {}, frameAttrs = {}, cardId = null) => {
 	if (!fields.media?.length) return null;
 	let frames = '';
 	let embed = null;
@@ -227,28 +309,11 @@ const buildMedia = (fields, type, tokens, preset = {}, frameAttrs = {}) => {
 			itemprop: NO_IMAGE_PROP.has(type) ? null : 'image'
 		})}>`;
 	}
-	let furniture = '';
-	if (fields.play) {
-		furniture += `<ui-play><button type="button" aria-label="Play" command="--toggle-play"><ui-icon type="play-pause"></ui-icon></button></ui-play>`;
-		tokens.media.push(`play(${fields.play.position || 'cc'})`);
-		if (fields.play.hue) tokens.media.push(`play(${fields.play.hue})`);
-		if (fields.play.size) tokens.media.push(`ply(${fields.play.size})`);
-	}
-	if (fields.chip?.text) {
-		furniture += `<ui-chip>${esc(fields.chip.text)}</ui-chip>`;
-		tokens.media.push(`chip(${fields.chip.position || 'ts'})`);
-		if (fields.chip.hue) tokens.media.push(`chip(${fields.chip.hue})`);
-	}
-	if (fields.sticker?.text) {
-		furniture += `<ui-sticker${fields.sticker.burst ? ' variant="burst"' : ''}><strong>${esc(fields.sticker.text)}</strong></ui-sticker>`;
-		tokens.media.push(`sticker(${fields.sticker.position || 'te'})`);
-		if (fields.sticker.hue) tokens.media.push(`sticker(${fields.sticker.hue})`);
-	}
-	if (fields.saveable) {
-		furniture += `<ui-save><input type="checkbox" aria-label="Save ${esc(plain(fields.headline) || 'card')} to favorites"></ui-save>`;
-		tokens.media.push('save(ts)');
-	}
+	/* save needs a command target — id the frame when a save toggle is present */
+	const mediaId = (fields.furniture?.save && cardId) ? `${cardId}-media` : null;
+	const furniture = buildFurniture(fields.furniture, fields, tokens, mediaId);
 	const html = `<ui-media${attrs({
+		id: mediaId,
 		nav: preset.nav || null,
 		arrow: preset.arrow || null,
 		dot: preset.dot || null,
@@ -670,8 +735,8 @@ const flipsideBack = (flipside) => {
 	return contentColumn(fields, type, false, '', 'both');
 };
 
-const renderReveal = (fields, type, itemtype, tokens, preset, flipside) => {
-	const media = buildMedia(fields, type, tokens, preset);
+const renderReveal = (fields, type, itemtype, tokens, preset, flipside, cardId = null) => {
+	const media = buildMedia(fields, type, tokens, preset, {}, cardId);
 	const front = `<ui-face>
 		${media?.html || ''}
 		<ui-content>
@@ -692,7 +757,7 @@ const renderReveal = (fields, type, itemtype, tokens, preset, flipside) => {
 		trigger: reveal.trigger || null,
 		scroll: !!reveal.scroll,
 		variant: preset.variant || null,
-		media: [preset.media, ...tokens.media].filter(Boolean).join(' ') || null,
+		media: mergeMediaTokens(preset.media, tokens.media) || null,
 		content: preset.content || null,
 		style: styleAttr(preset.styles),
 		itemscope: true,
@@ -742,23 +807,24 @@ export async function loadPresets(url) {
  */
 export function renderCard(ucf, presets = {}, cards = {}) {
 	const fields = ucf?.fields ?? ucf ?? {};
+	const cardId = ucf?.id || null;
 	const type = SCHEMA_TYPES[fields.schemaType] ? fields.schemaType : 'content';
 	const itemtype = SCHEMA + SCHEMA_TYPES[type];
 	const preset = resolvePreset(fields, presets);
 	const tokens = { media: [] };
 
 	if (preset.element === 'ui-reveal') {
-		return renderReveal(fields, type, itemtype, tokens, preset, resolveCard(fields.flipside, cards));
+		return renderReveal(fields, type, itemtype, tokens, preset, resolveCard(fields.flipside, cards), cardId);
 	}
 
 	/* Bare <ui-media> — a standalone media frame, no card chrome. The media
 	   token string sits on the element itself (rds() applies outside a card). */
 	if (preset.element === 'ui-media') {
 		const caption = fields.media?.find((item) => item.caption)?.caption;
-		const media = buildMedia(fields, type, tokens, preset, {});
+		const media = buildMedia(fields, type, tokens, preset, {}, cardId);
 		const inner = (media?.html || '<ui-media></ui-media>')
 			.replace('<ui-media', `<ui-media${attrs({
-				media: [preset.media, ...tokens.media].filter(Boolean).join(' ') || null,
+				media: mergeMediaTokens(preset.media, tokens.media) || null,
 				style: styleAttr(preset.styles),
 				itemscope: true,
 				itemtype
@@ -777,11 +843,11 @@ export function renderCard(ucf, presets = {}, cards = {}) {
 		})}>${contentColumn(fields, type, false, '', preset.text || 'summary')}</ui-content>`;
 	}
 
-	const media = buildMedia(fields, type, tokens, preset);
+	const media = buildMedia(fields, type, tokens, preset, {}, cardId);
 	const overlay = /ovr\(/.test(preset.variant || '');
 	return `<ui-card${attrs({
 		variant: preset.variant || 'col',
-		media: [preset.media, ...tokens.media].filter(Boolean).join(' ') || null,
+		media: mergeMediaTokens(preset.media, tokens.media) || null,
 		content: preset.content || null,
 		style: styleAttr(preset.styles),
 		itemscope: true,

--- a/ui/card/schema.html
+++ b/ui/card/schema.html
@@ -161,12 +161,12 @@
 	<h2>Product — <code>Product</code></h2>
 	<p class="note">Offer + AggregateRating, discount <code>&lt;ui-sticker&gt;</code>, save toggle. Proposed parts: <code>price</code>, <code>rating</code>.</p>
 	<div class="grid grid-2">
-		<ui-card variant="col" media="asr(4/3) sticker(te) sticker(red) save(ts)" itemscope itemtype="https://schema.org/Product">
+		<ui-card variant="col" media="asr(4/3) sticker(te) sticker(red) sticker(burst) save(ts)" itemscope itemtype="https://schema.org/Product">
 			<cq-box>
-				<ui-media>
+				<ui-media id="product-1-media">
 					<img src="/assets/images/aurasoundpro.png" alt="AuraSound Pro wireless headphones" itemprop="image">
-					<ui-sticker variant="burst"><strong>-20%</strong></ui-sticker>
-					<ui-save><input type="checkbox" aria-label="Save AuraSound Pro to favorites"></ui-save>
+					<ui-sticker><strong>-20%</strong></ui-sticker>
+					<ui-save><button type="button" command="--save" commandfor="product-1-media" aria-label="Save AuraSound Pro to favorites"><ui-icon type="shape" shape="heart" variant="outline"></ui-icon></button></ui-save>
 				</ui-media>
 				<ui-content>
 					<meta itemprop="category" content="Electronics">


### PR DESCRIPTION
## Summary

Replaces the four sibling furniture fields (`chip` / `sticker` / `play` / `saveable`) with a single **`furniture`** object in the card content model that carries **only text/semantics**. Visual config (position, hue, size, shape) now lives in the **preset's `media=` token string**, with an optional per-item **`style`** override that wins per-axis. This adopts the pattern the hand-authored `media.furniture.html` demo already used.

> Targets **`v4`** (the branch the card system lives on), not `main`.

## Changes

- **`cms/baseline/models/card.schema.json`** — unified `furniture` object. The sticker's text is now a structured `lines[]` array (`role: label|lead|plain` → `<small>`/`<strong>`/`<span>`, optional `<sup>`), fixing the old flat `sticker.text` that could only ever emit one `<strong>`. `save`/`play` accept a bare `true`.
- **`cms/baseline/models/card-preset.schema.json`** — documents the furniture look tokens on `media=` (single value per token; the CSS matches by substring, so `chip(ts red)` is invalid — use `chip(ts) chip(red)`).
- **`ui/card/render.js`** — `buildFurniture()` emits the elements from the `furniture` object and no longer generates position/hue tokens. `mergeMediaTokens()` merges preset `media` with per-item `style` overrides, stripping the preset's same-axis token so overrides win deterministically (CSS resolves `media=` by source-order, not token-order). Save emits the `<button command="--save" commandfor="{id}-media"><ui-icon shape=…></button>` form instead of a checkbox.
- **`ui/card/data/*.json` + `data/demo/*.json`** — migrate all furniture. Tokens hoisted into the six 1:1 demo presets in `card.presets.demo.json`; per-card `style` overrides kept where presets are shared.
- **`ui/card/schema.html`** — product save reference updated to the button + icon form.
- **`ui/card/card.md`** — furniture documentation rewritten.

## Verification

- All 100 data files render with **0 errors**; every furniture element present.
- Override precedence confirmed (`sticker(green)` replaced by `sticker(red)`), save `commandfor` wiring, and the `ply()`→`play()` size rename (all render pages load `ui-play.css`, which matches `play(lg/xl)`).
- Browser check (Chromium): chips and multi-line stickers render/position correctly from preset tokens; migration is byte-identical for unchanged output (news `Breaking` chip).

## Note

An **unsaved** save glyph (`<ui-icon variant="outline">`) renders as a square in browsers without the bleeding-edge `border-shape` CSS property (`ui-icon.css`). This is pre-existing — it affects the hand-authored `media.furniture.html` reference identically — and is a component/browser-support matter, not introduced by this change. The renderer emits exactly the documented markup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016wGVmcUc26dt7G52MdoZ9t)_