### PR TITLE
feat(card,layout): use <lay-out> for card/reveal demo grids + integration plan

### DIFF
--- a/layout/docs/card-integration.md
+++ b/layout/docs/card-integration.md
@@ -1,0 +1,173 @@
+# Card × Layout Integration
+
+How the root-level **layout system** (`/layout`, `<lay-out>`) and the **card system** (`ui/card`, `ui/reveal`) compose — and the phased plan to make them one story, from demo grids to a shared, editor-ready JSON format.
+
+**Status:** Phase 1 (proof of concept) implemented — `ui/card/index.html` and `ui/reveal/index.html` use `<lay-out>` instead of hard-coded `.grid` classes. Phases 2–6 are specified below, not yet implemented.
+
+## Why
+
+Every card/reveal demo page used to define its own `.grid` / `.grid-2/3/4` classes in an inline `<style>` block. A census of the 17 demo pages found three different breakpoint conventions for the same visual intent:
+
+| Pages | Classes | Breakpoints |
+|---|---|---|
+| `ui/card/render.html`, `article.render.html`, most `media.*.html` (13 pages) | `.grid-2/.grid-3` | 540px |
+| pages with `.grid-4` (9 pages, overlapping) | `.grid-4` | 540px → 2-col, 900px → 4-col |
+| `ui/card/index.html`, `ui/reveal/index.html` | `.grid-2/.grid-3` | 720px |
+
+Duplicated, inconsistent, and expressible only as uniform columns. Meanwhile `/layout` generates exactly this kind of CSS from JSON (`layout.config.json` + `layouts/*.json` → `dist/layout.css`), with a far richer vocabulary (`grid()`, `bento()`, `mosaic()`, `asym()`, `ratios()` …), consistent breakpoints, and a format prepared for a visual editor.
+
+## The composition model — two axes, two systems
+
+The systems compose cleanly **by construction**:
+
+- **`<lay-out md="…" lg="…">`** — *viewport* `@media` queries (xs 240 / sm 380 / md 540 / lg 720 / xl 920 / xxl 1140 px). Decides the **section layout**: how many cells, what pattern, which card gets a wide cell.
+- **card `md:` / `lg:` token prefixes** (in `variant=` / `content=`) — *container* queries on the card's **own width** (`md` ≥ 25rem/400px, `lg` ≥ 44rem/704px, queried via `<cq-box>` / `<summary>`). Decides the **card's internal arrangement**: stacked vs row, split ratios, spacing.
+
+Chain of effects: viewport width → `lay-out` picks a pattern → each cell gets a width → each card's container queries react to that width. One markup, no coordination needed.
+
+Worked example (live on `ui/card/index.html`, "Layout system" section):
+
+```html
+<lay-out md="columns(2)" lg="grid(3a)">
+  <ui-card variant="col lg:row lg:spl(1/1)" media="asr(16/9)">…</ui-card>
+  <ui-card variant="col lg:row lg:spl(1/1)" media="asr(16/9)">…</ui-card>
+  <ui-card variant="col lg:row lg:spl(1/1)" media="asr(16/9)">…</ui-card>
+</lay-out>
+```
+
+At viewport ≥ 720px, `grid(3a)` gives the first two cards half-width cells (~below 44rem → they stay `col`, stacked) and the third card the full bottom row (crosses 44rem → `lg:row lg:spl(1/1)` kicks in, media beside content). All three cards have **identical markup**.
+
+### Why it doesn't collide
+
+- `lay-out` has `contain: layout inline-size` but **no `container-type`** — it never becomes a query container, so `cq-box`/`summary` still resolve to their `ui-card`/`ui-reveal` ancestor.
+- Card CSS lives in `@layer bs-component` (base in `bs-core`); layout CSS in `@layer layout.*`. Zero selector/layer overlap.
+- `lay-out > *:not(lay-out) { grid-area: var(--_ga, var(--layout-ga, auto)) }` is harmless — cards never set their own `grid-area`.
+- **One known conflict:** `dist/layout.css` ends with an *unlayered* `body { margin-inline: max(…) }` rule (generated from `layoutContainer` in `layout.config.json`) that beats base's `:where(body) { margin-inline: auto }`. Demo pages counter it in `ui/card/demo.layout.css`; the upstream fix (Phase 6) is to emit that rule inside `@layer layout.base`.
+
+### Naming: keep both vocabularies
+
+Both systems use "md"/"lg", meaning different things (viewport attribute vs container token prefix). **Recommendation: don't rename either.** They never co-occur on one element — `md=` is an attribute on `<lay-out>`, `md:` a prefix inside `variant=`/`content=` — and both systems are published. One deliberate near-alignment worth knowing: card-`lg` (44rem = 704px) ≈ layout-`lg` (720px), so a full-bleed card flips to its `lg` tier just before the section re-flows.
+
+### Browser support note
+
+Generated variant rules use literal values (`--layout-gtc: 1fr 1fr 1fr`), so patterns work everywhere. The *attribute-driven* props (`col-gap=`, `pad-inline=`, `bleed=` …) use typed `attr()` (Chromium-only) — pages must load `/layout/polyfills/attr-fallback.js` for Safari/Firefox, or gaps silently disappear.
+
+## Usage pattern (Phase 1, implemented)
+
+Includes (demos are served from the repo root):
+
+```html
+<link rel="stylesheet" href="/ui/base/index.css">
+<link rel="stylesheet" href="/layout/dist/layout.css">
+<link rel="stylesheet" href="ui-card.css">
+<link rel="stylesheet" href="/ui/card/demo.layout.css">
+<script type="module" src="/layout/polyfills/attr-fallback.js"></script>
+```
+
+Do **not** include `/layout/demo.css` — it styles layout's own demo furniture (`item-card`, `body { display: grid }`).
+
+`ui/card/demo.layout.css` is a tiny unlayered shim: re-asserts body centering (see conflict above) and maps the old `.grid` rhythm onto layout (`--layout-space-unit: var(--spacing-lg)`, `margin-block-end: var(--spacing-2xl)`).
+
+**Variant guidance for card lists:** all `columns(N)` and `grid(N…)` variants are `repeatable: true` — safe for any card count. `asym()`, and some `bento()`/`mosaic()` variants hide children beyond their pattern (`nth-child(n+…) { display: none }`) — only use them when the item count matches the pattern's `items`.
+
+## Phase 2 — migrate the remaining ~15 demo pages
+
+Mapping table (normalizes the 540/720/900 inconsistency to layout's canonical breakpoints):
+
+| Old wrapper | New wrapper |
+|---|---|
+| `.grid grid-2` @ 540 | `<lay-out md="columns(2)">` |
+| `.grid grid-2` @ 720 | `<lay-out lg="columns(2)">` |
+| `.grid grid-3` @ 540 | `<lay-out md="columns(2)" lg="columns(3)">` |
+| `.grid grid-3` @ 720 | `<lay-out lg="columns(3)">` |
+| `.grid grid-4` @ 540/900 | `<lay-out md="columns(2)" xl="columns(4)">` |
+| lone hero card | leave unwrapped |
+
+JS-created wrappers (`render.html` and friends): `<lay-out>` needs no registration — pure CSS —
+
+```js
+const grid = document.createElement('lay-out');
+grid.setAttribute('md', 'columns(2)');
+```
+
+Then delete each page's inline `.grid*` styles and add the includes above.
+
+## Phase 3 — srcset bridge
+
+Both systems compute responsive-image hints, differently:
+
+- **layout:** each variant's `srcset` field (% width per item) is compiled into `layouts-map.js`; `src/srcsets.js` `generateSrcsets()` produces a `srcsets="540:50%;720:50%,50%,100%@1024"` attribute and `calculateSizes(srcsets, childIndex)` turns it into a real `sizes` string per child.
+- **card:** `ui/card/ui-media-srcset.js` builds Cloudflare-CDN `srcset` from a fixed width list (`[240,320,480,720,1200]`) with `sizes="auto"` — it knows nothing about the cell the card occupies.
+
+Bridge (minimal, progressive enhancement): keep the CDN width list, fix `sizes` from layout context —
+
+```js
+// in ui-media-srcset.js
+#layoutSizes() {
+  const layout = this.closest('lay-out');
+  const srcsets = layout?.getAttribute('srcsets');
+  if (!srcsets) return null;
+  const cell = [...layout.children].find(c => c.contains(this));
+  return calculateSizes(srcsets, [...layout.children].indexOf(cell));
+}
+// upgrade(): sizes = this.#layoutSizes() ?? cfg.sizes
+```
+
+Coupling rule: `calculateSizes` must be **injected** (e.g. via `globalThis.uiMedia` or a guarded dynamic import), never a hard dependency of the published `@browser.style/ui-card` package. The `srcsets` attribute comes from (a) hand-authoring, (b) loading layout's `<lay-out>` web component (`/layout/src/components/layout/index.js`, derives it from the breakpoint attributes via `layouts-map.js`), or (c) SSR (Phase 4).
+
+Known imprecision: `calculateSizes` emits `vw`-based sizes assuming `lay-out` spans the viewport (capped at `@1024`); inside an 85ch-capped body it slightly over-requests. Acceptable; a container-relative refinement belongs in layout v2.
+
+## Phase 4 — section preset + section renderer (SSR)
+
+The shared, editor-ready format. One JSON document describes a **section**: a layout config plus the cards inside it, each with an optional card-preset override. Builds on the schemas that already exist — `cms/baseline/models/layout-config.schema.json` (per-breakpoint token strings) and `card-preset.schema.json` — not a new vocabulary. The layout half is exactly what the composer (`layout/src/components/composer/`, `model.json`) already edits; the card half is what a future card editor would edit.
+
+```json
+{
+  "model": "section",
+  "id": "front-teasers",
+  "layout": {
+    "md": "columns(2)", "lg": "grid(3a)",
+    "colGap": 2, "rowGap": 2, "spaceBottom": 3, "bleed": 0, "width": "xl"
+  },
+  "items": [
+    { "card": { "$ref": "card/article-001" }, "preset": { "$ref": "card-preset/stack" } },
+    { "card": { "$ref": "card/product-001" }, "preset": { "$ref": "card-preset/showcase" } },
+    { "card": { "$ref": "card/event-001" } }
+  ]
+}
+```
+
+- Schema: `cms/baseline/models/section.schema.json`. `layout` either inlines the layout-config fields or `$ref`s a stored layout-config — support both, like `preset` refs work today.
+- Renderer: `ui/card/render-section.js`, string-based and Node-safe like `render.js`:
+
+```js
+import { renderCard } from './render.js';
+
+export function renderSection(section, presets = {}, cards = {}, layoutTools = null) {
+  const l = section.layout ?? {};
+  const bp = Object.fromEntries(
+    ['xs','sm','md','lg','xl','xxl'].filter(k => l[k]).map(k => [k, l[k]]));
+  const srcsets = layoutTools
+    ? layoutTools.generateSrcsets(bp, layoutTools.srcsetMap, layoutTools.layoutConfig)
+    : null;
+  const items = section.items.map(it =>
+    renderCard(withPreset(resolveCard(it.card, cards), it.preset), presets, cards)).join('');
+  return `<lay-out${attrs({ ...bp, 'col-gap': l.colGap, 'row-gap': l.rowGap,
+    bleed: l.bleed, width: l.width, overflow: l.overflow, srcsets })}>${items}</lay-out>`;
+}
+```
+
+`layoutTools` (`{ generateSrcsets, srcsetMap, layoutConfig }` from `/layout/src/srcsets.js` + `/layout/layouts-map.js`) is injected so `render-section.js` has no hard layout dependency. The emitted `srcsets` attribute is what the Phase 3 bridge consumes — SSR layout context flows into client image `sizes` with no extra plumbing. True SSR `srcset` on `<img>` inside `render.js` is the follow-up that retires `ui-media-srcset.js` entirely (it's documented as transitional).
+
+- Validation: a section referencing a non-`repeatable` variant should check `items.length` against the variant's `items` count in `layouts/*.json` (the composer's `model.json` already carries this metadata).
+- Demo: `ui/card/section.render.html` + a sample `ui/card/data/sections/*.json`.
+
+## Phase 5 — visual editor alignment
+
+The layout composer (`layout/src/components/composer/`) edits exactly the `layout` half of a section. Whether cards get their own visual editor is still undecided; the section format above keeps that door open — a card editor would edit `items[n].preset` (+ the preset collections in `ui/card/data/card.presets.json`) without touching the layout half. The layout v2 roadmap (`layout/.tmp/todo.md`, Phases 2/5: `LayoutPreset`, `presetToAttributes`, configurator package, Sanity.io schema) slots in as the persistence/UI layer for the same document.
+
+## Phase 6 — upstream cleanups
+
+- `layout/src/builder.js`: emit the generated `layoutContainer` `body` rule inside `@layer layout.base`, then drop the counter-rule from `demo.layout.css`.
+- Remove `.grid` guidance from card docs; point to this document.
+- Optional: a `cards` theme in layout demos so `item-card` placeholders can be replaced by real `<ui-card>`s in `/layout/dist/*.html` demos too.

--- a/ui/card/demo.layout.css
+++ b/ui/card/demo.layout.css
@@ -1,0 +1,19 @@
+/**
+ * Demo-only shim for using /layout/dist/layout.css on card/reveal demo pages.
+ * Unlayered on purpose so it wins over both bs-* and layout.* layers.
+ */
+
+/* layout.css ends with an unlayered `body { margin-inline: max(…) }` rule
+   (generated from layoutContainer in layout.config.json) that assumes the
+   layout owns the page. The demo pages are centered by base's
+   :where(body) { margin-inline: auto } — re-assert that here. */
+body {
+	margin-inline: auto;
+}
+
+lay-out {
+	/* layout gaps are n × --layout-space-unit (default 1rem);
+	   match the rhythm the old .grid wrappers had (gap: --spacing-lg) */
+	--layout-space-unit: var(--spacing-lg, 1.5rem);
+	margin-block-end: var(--spacing-2xl);
+}

--- a/ui/card/index.html
+++ b/ui/card/index.html
@@ -6,20 +6,14 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 	<meta name="description" content="CSS-first card composing &lt;ui-media&gt; + &lt;ui-content&gt;, configured with media=/content=/variant= token DSLs, a container-driven font scale, responsive layout tiers and themes.">
 	<link rel="stylesheet" href="/ui/base/index.css">
+	<link rel="stylesheet" href="/layout/dist/layout.css">
 	<link rel="stylesheet" href="../chip/ui-chip.css">
 	<link rel="stylesheet" href="../sticker/ui-sticker.css">
 	<link rel="stylesheet" href="ui-card.css">
+	<link rel="stylesheet" href="demo.layout.css">
+	<!-- typed attr() fallback for Safari/Firefox (layout gaps/spacing attributes) -->
+	<script type="module" src="/layout/polyfills/attr-fallback.js"></script>
 	<style>
-		.grid {
-			display: grid;
-			gap: var(--spacing-lg);
-			grid-template-columns: 1fr;
-			margin-block-end: var(--spacing-2xl);
-		}
-		@media (min-width: 720px) {
-			.grid-2 { grid-template-columns: repeat(2, 1fr); }
-			.grid-3 { grid-template-columns: repeat(3, 1fr); }
-		}
 		.hero { margin-block-end: var(--spacing-2xl); }
 		.note { color: var(--color-text-secondary, #666); }
 	</style>
@@ -32,7 +26,7 @@
 	     Article cards — realistic content, stacked (col)
 	     ============================================================ -->
 	<h2>Article cards</h2>
-	<div class="grid grid-3">
+	<lay-out lg="columns(3)">
 		<ui-card variant="col" media="asr(16/9)">
 			<cq-box>
 				<ui-media><img src="/assets/images/popovers.png" alt="" loading="lazy"></ui-media>
@@ -83,7 +77,7 @@
 				</ui-content>
 			</cq-box>
 		</ui-card>
-	</div>
+	</lay-out>
 
 	<!-- ============================================================
 	     Responsive layout — row when wide, col when narrow (lg: prefix).
@@ -104,7 +98,7 @@
 		</cq-box>
 	</ui-card>
 
-	<div class="grid grid-3">
+	<lay-out lg="columns(3)">
 		<ui-card variant="col lg:row lg:spl(1/1)" media="asr(16/9)">
 			<cq-box>
 				<ui-media><img src="/assets/images/destinations.png" alt="" loading="lazy"></ui-media>
@@ -135,7 +129,50 @@
 				</ui-content>
 			</cq-box>
 		</ui-card>
-	</div>
+	</lay-out>
+
+	<!-- ============================================================
+	     Layout system — <lay-out> from /layout wrapping cards.
+	     grid(3a): two half-width cells on top, one full-width below —
+	     a pattern the old .grid classes could never express. The full-width
+	     card crosses its own lg container tier (44rem) and flips to lg:row,
+	     while the half-width copies stay stacked. Two systems, one markup.
+	     ============================================================ -->
+	<h2>Layout system — <code>&lt;lay-out&gt;</code></h2>
+	<p class="note">The section layout comes from <code>/layout</code> (<code>md="columns(2)" lg="grid(3a)"</code>, viewport-driven); each card still adapts to its own cell width via container queries. All three cards share identical <code>variant="col lg:row lg:spl(1/1)"</code> markup — only the full-width one flips to a row.</p>
+	<lay-out md="columns(2)" lg="grid(3a)">
+		<ui-card variant="col lg:row lg:spl(1/1)" media="asr(16/9)">
+			<cq-box>
+				<ui-media><img src="/assets/images/popovers.png" alt="" loading="lazy"></ui-media>
+				<ui-content>
+					<small data-part="eyebrow">Web Development</small>
+					<h2 data-part="headline">Half-width cell — stays stacked</h2>
+					<p data-part="summary">This card sits in a 1-of-2 cell, below its own <code>lg</code> tier, so the default <code>col</code> arrangement applies.</p>
+				</ui-content>
+			</cq-box>
+		</ui-card>
+		<ui-card variant="col lg:row lg:spl(1/1)" media="asr(16/9)">
+			<cq-box>
+				<ui-media><img src="/assets/images/quantum.png" alt="" loading="lazy"></ui-media>
+				<ui-content>
+					<small data-part="eyebrow">Technology</small>
+					<h2 data-part="headline">Half-width cell — stays stacked</h2>
+					<p data-part="summary">Identical markup to its neighbours; the cell width decides the arrangement.</p>
+				</ui-content>
+			</cq-box>
+		</ui-card>
+		<ui-card variant="col lg:row lg:spl(1/1)" media="asr(16/9)">
+			<cq-box>
+				<ui-media><img src="/assets/images/websummit.png" alt="" loading="lazy"></ui-media>
+				<ui-content>
+					<small data-part="eyebrow">Featured</small>
+					<h2 data-part="headline">Full-width cell — flips to a row</h2>
+					<p data-part="summary">The <code>grid(3a)</code> pattern gives this card the whole bottom row. Its own width crosses the card's <code>lg</code> container tier (44rem), so <code>lg:row lg:spl(1/1)</code> kicks in — media beside content.</p>
+					<nav data-part="actions"><a class="ui-button" href="#">Read more</a></nav>
+				</ui-content>
+			</cq-box>
+		</ui-card>
+	</lay-out>
 
 	<!-- ============================================================
 	     Hero — overlay (static). Content stacked over media with a scrim.
@@ -158,7 +195,7 @@
 	     Overlay positions — realistic featured cards
 	     ============================================================ -->
 	<h2>Overlay — featured</h2>
-	<div class="grid grid-3">
+	<lay-out lg="columns(3)">
 		<ui-card variant="ovr(bl)" media="asr(3/4) obp(cc)" content="scl(lg)">
 			<cq-box>
 				<ui-media><img src="/assets/images/mindfulness.png" alt="" loading="lazy"></ui-media>
@@ -186,14 +223,14 @@
 				</ui-content>
 			</cq-box>
 		</ui-card>
-	</div>
+	</lay-out>
 
 	<!-- ============================================================
 	     Media overlays — <ui-chip> label + <ui-sticker> callout
 	     ============================================================ -->
 	<h2>Media overlays — chip &amp; sticker</h2>
 	<p class="note">Overlay furniture lives inside <code>&lt;ui-media&gt;</code>; position and sub-theme come from the parent <code>media=</code> token (<code>chip(&lt;pos&gt;)</code> / <code>sticker(&lt;pos&gt;)</code>, <code>chip(&lt;hue&gt;)</code>). <code>&lt;ui-chip&gt;</code> is a pill label; <code>&lt;ui-sticker&gt;</code> is a disc, or a starburst with <code>variant="burst"</code>.</p>
-	<div class="grid grid-3">
+	<lay-out lg="columns(3)">
 		<ui-card variant="col" media="asr(4/3) chip(be) chip(green) sticker(ts) sticker(red)">
 			<cq-box>
 				<ui-media>
@@ -237,12 +274,12 @@
 				</ui-content>
 			</cq-box>
 		</ui-card>
-	</div>
+	</lay-out>
 
 	<!-- Video + bare scroller -->
 	<h2>Video &amp; multi-source scroller</h2>
 	<p class="note"><code>&lt;ui-media&gt;</code> accepts a <code>&lt;video&gt;</code> (native controls/poster) just like an image. Add <code>media="nav"</code> for multiple sources — a flex scroll-snap row. <code>nav(non)</code> leaves it a bare swipe scroller, no JS.</p>
-	<div class="grid grid-2">
+	<lay-out lg="columns(2)">
 		<ui-card variant="col" media="asr(16/9) chip(ts) chip(blue)">
 			<cq-box>
 				<ui-media>
@@ -273,12 +310,12 @@
 				</ui-content>
 			</cq-box>
 		</ui-card>
-	</div>
+	</lay-out>
 
 	<!-- Carousel — CSS-only dots + arrows -->
 	<h2>Carousel — <code>media="nav"</code></h2>
 	<p class="note">A scroll-snap row of sources, plus CSS-only navigation dots (<code>::scroll-marker</code>) and prev/next arrows (<code>::scroll-button()</code>) shown by default. No JavaScript. Chromium-only for now — elsewhere it degrades to the plain swipe scroller.</p>
-	<div class="grid grid-2">
+	<lay-out lg="columns(2)">
 		<ui-card variant="col" media="asr(16/9) nav" content="scl(lg)">
 			<cq-box>
 				<ui-media>
@@ -310,12 +347,12 @@
 				</ui-content>
 			</cq-box>
 		</ui-card>
-	</div>
+	</lay-out>
 
 	<!-- Carousel controls — pick pieces + theme them -->
 	<h2>Carousel controls &amp; theming</h2>
 	<p class="note">Pick controls with <code>nav(dot)</code>, <code>nav(arw)</code>, bare <code>nav</code> (both), or <code>nav(non)</code>. Colours, dot size and the arrow glyphs are all tokens.</p>
-	<div class="grid grid-3">
+	<lay-out lg="columns(3)">
 		<ui-card variant="col" media="asr(4/3) nav(dot)" content="scl(sm)">
 			<cq-box>
 				<ui-media>
@@ -349,14 +386,14 @@
 				<ui-content><small data-part="eyebrow">themed</small><h2 data-part="headline">Accent circle via <code>--ui-media-arrow-bg</code></h2></ui-content>
 			</cq-box>
 		</ui-card>
-	</div>
+	</lay-out>
 
 	<!-- ============================================================
 	     Themes — thm()
 	     ============================================================ -->
 	<h2>Themes — <code>thm()</code></h2>
 	<p class="note">The same card in default, <code>thm(dark)</code> and <code>thm(brand)</code>. Theme tokens remap surface, ink, eyebrow and tag colours.</p>
-	<div class="grid grid-3">
+	<lay-out lg="columns(3)">
 		<ui-card variant="col" media="asr(16/9)">
 			<cq-box>
 				<ui-media><img src="/assets/images/fittrackpro.png" alt="" loading="lazy"></ui-media>
@@ -395,13 +432,13 @@
 				</ui-content>
 			</cq-box>
 		</ui-card>
-	</div>
+	</lay-out>
 
 	<!-- ============================================================
 	     Profile + product — row, realistic
 	     ============================================================ -->
 	<h2>Profile &amp; product</h2>
-	<div class="grid grid-2">
+	<lay-out lg="columns(2)">
 		<ui-card variant="row spl(1/2)" media="asr(1/1)">
 			<cq-box>
 				<ui-media><img src="/assets/images/janesmith.png" alt="" loading="lazy"></ui-media>
@@ -427,7 +464,7 @@
 				</ui-content>
 			</cq-box>
 		</ui-card>
-	</div>
+	</lay-out>
 	<!-- cursor-tracked hover + loop/auto carousels (progressive enhancement) -->
 	<script type="module" src="index.js"></script>
 </body>

--- a/ui/reveal/index.html
+++ b/ui/reveal/index.html
@@ -7,18 +7,12 @@
 	<meta name="description" content="CSS-only reveal card built on details/summary with cover, flip, slide, and scale animations.">
 	<meta name="view-transition" content="same-origin">
 	<link rel="stylesheet" href="/ui/base/index.css">
+	<link rel="stylesheet" href="/layout/dist/layout.css">
 	<link rel="stylesheet" href="ui-reveal.css">
+	<link rel="stylesheet" href="/ui/card/demo.layout.css">
+	<!-- typed attr() fallback for Safari/Firefox (layout gaps/spacing attributes) -->
+	<script type="module" src="/layout/polyfills/attr-fallback.js"></script>
 	<style>
-		.grid {
-			display: grid;
-			gap: var(--spacing-lg);
-			grid-template-columns: 1fr;
-			margin-block-end: var(--spacing-2xl);
-		}
-		@media (min-width: 720px) {
-			.grid { grid-template-columns: repeat(3, 1fr); }
-			.grid-2 { grid-template-columns: repeat(2, 1fr); }
-		}
 		.hero {
 			display: block;
 			margin-block-end: var(--spacing-2xl);
@@ -48,7 +42,7 @@
 	     ============================================ -->
 	<h2>New releases</h2>
 
-	<div class="grid">
+	<lay-out lg="columns(3)">
 		<ui-card variant="ovr(bl) rds(md-sq)" media="asr(3/4) obp(cc) scm">
 			<cq-box>
 				<ui-media><img src="/assets/images/game_01.png" alt="" loading="lazy"></ui-media>
@@ -78,7 +72,7 @@
 				</ui-content>
 			</cq-box>
 		</ui-card>
-	</div>
+	</lay-out>
 
 	<!-- ============================================
 	     The same three cards as <ui-reveal> — adds the reveal behaviour.
@@ -89,7 +83,7 @@
 	     ============================================ -->
 	<h2>New releases <code>&lt;ui-reveal&gt;</code></h2>
 
-	<div class="grid">
+	<lay-out lg="columns(3)">
 		<ui-reveal type="expand" to="viewport" icon="top right semi" variant="ovr(bl) rds(md-sq)" media="asr(3/4) obp(cc) scm" style="--ui-reveal-expand-fixed-bg:#6a69ab;">
 			<details>
 				<summary>
@@ -146,7 +140,7 @@
 				</ui-content>
 			</details>
 		</ui-reveal>
-	</div>
+	</lay-out>
 
 	<!-- ============================================
 	     Cover story as a plain <ui-card> — mirrored media via flp(h),
@@ -198,7 +192,7 @@
 	     ============================================ -->
 	<h2>Quick info</h2>
 
-	<div class="grid">
+	<lay-out lg="columns(3)">
 		<ui-card media="asr(6/7) obp(tc)">
 			<cq-box>
 				<ui-media><img src="/assets/images/band_britpop.png" alt="Camden Court" loading="lazy"></ui-media>
@@ -234,11 +228,11 @@
 				</ui-content>
 			</cq-box>
 		</ui-card>
-	</div>
+	</lay-out>
 
 	<h2>What we're listening to</h2>
 
-	<div class="grid">
+	<lay-out lg="columns(3)">
 		<ui-reveal class="thelure" icon="top right sm" icon-close="dark" type="flip" variant="ovr(tl) rds(lg-sq)" media="asr(1/1) hov(zoom) obp(tc)" scroll>
 			<details name="flip">
 				<summary>
@@ -418,7 +412,7 @@
 				</ui-content>
 			</details>
 		</ui-reveal>
-	</div>
+	</lay-out>
 
 	<!-- ============================================
 	     Tap the whole card — trigger="card" (ar 2/3)
@@ -426,7 +420,7 @@
 	<h2>Tap the whole card</h2>
 	<p>Three from the lineup, up close — tap anywhere, front <em>or</em> back, to turn the card over. Links on the back still work.</p>
 
-	<div class="grid">
+	<lay-out lg="columns(3)">
 		<ui-reveal type="flip" trigger="card" from="left" variant="ovr(bl)" media="asr(2/3) hov(track) scm">
 			<details>
 				<summary>
@@ -474,7 +468,7 @@
 				</ui-content>
 			</details>
 		</ui-reveal>
-	</div>
+	</lay-out>
 
 	<!-- ============================================
 	     However you frame it — media position
@@ -482,7 +476,7 @@
 	<h2>However you frame it</h2>
 	<p>The same lineup, framed four ways — image above, below, left or right of the words.</p>
 
-	<div class="grid grid-2">
+	<lay-out lg="columns(2)">
 		<!-- media top (col, default) -->
 		<ui-reveal icon="bottom right dark" type="slide" from="top" media="asr(16/9) hov(zoom)" style="--ui-reveal-bg:#f49d98;">
 			<details>
@@ -558,7 +552,7 @@
 				</ui-content>
 			</details>
 		</ui-reveal>
-	</div>
+	</lay-out>
 
 	<!-- optional responsive-image upgrade (host-gated Cloudflare srcset; transitional until SSR) -->
 	<script type="module" src="/ui/card/ui-media-srcset.js"></script>


### PR DESCRIPTION
## Summary

Proof of concept for using the root `/layout` system alongside the card system, plus a committed integration roadmap for the remaining phases.

- **`ui/card/index.html` + `ui/reveal/index.html`**: replaced all hard-coded `.grid`/`.grid-2/3` wrappers (inline `<style>`, inconsistent breakpoints) with `<lay-out lg="columns(2|3)">`. Pages now load `/layout/dist/layout.css` and the typed-`attr()` polyfill for Safari/Firefox.
- **New showcase section** on the card demo: `<lay-out md="columns(2)" lg="grid(3a)">` with three identical-markup cards — the two half-width cells stay stacked (`col`) while the full-width bottom card crosses its own 44rem container tier and flips to `lg:row`. Layout media queries pick the section pattern; card container queries adapt each card to its cell. Two systems, one markup.
- **`ui/card/demo.layout.css`**: demo-only shim — maps the old grid rhythm onto layout tokens (`--layout-space-unit: var(--spacing-lg)`) and counters the unlayered `body { margin-inline }` rule at the end of the built `layout.css`.
- **`layout/docs/card-integration.md`**: the full integration plan —
  - composition model (viewport `md=`/`lg=` vs container `md:`/`lg:`; recommendation to keep both vocabularies)
  - mapping table for migrating the remaining ~15 demo pages
  - srcset bridge design (`ui-media` derives `sizes` from the nearest `lay-out[srcsets]` via layout's `calculateSizes`, loosely coupled)
  - editor-ready **section preset** JSON format: one document combining a layout config with per-item card-preset refs, building on the existing `cms/baseline/models` schemas — the layout composer already edits the layout half
  - upstream cleanups (emit the generated `layoutContainer` body rule inside `@layer layout.base`)

## Verification

Served the repo root and drove both pages with Playwright/Chromium at 375/560/740/1100/1400px:
- correct column counts at every width; 24px gaps match the old `--spacing-lg` rhythm; body stays centered
- `grid(3a)` showcase measured at 1100px: card widths 406/406/836px — only the full-width card flips to `lg:row`
- no console errors beyond two pre-existing external assets blocked by the sandbox proxy
- `grep` confirms no leftover `.grid` classes or `<div>` wrappers on either page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QmwcyPipY6iUMrxBtTFBar

---
_Generated by [Claude Code](https://claude.ai/code/session_01QmwcyPipY6iUMrxBtTFBar)_