### PR TITLE
feat(carousel): dot(bar) — thin styled-scrollbar marker shape

### DIFF
--- a/ui/base/carousel.css
+++ b/ui/base/carousel.css
@@ -55,6 +55,30 @@
 	:where(ui-card, ui-reveal, ui-media, lay-out[overflow]):where([media*="dot(xl)"]) { --ui-carousel-dot-size: 1rem;    --ui-carousel-pill-width: 2.5rem;  --ui-carousel-pill-height: 0.55rem; --ui-carousel-thumb-size: 4.75rem; }
 	/* dot(tmb) — thumbnails get a larger inset */
 	:where(ui-card, ui-reveal, ui-media, lay-out[overflow]):where([media*="dot(tmb)"]) { --ui-carousel-marker-inset: var(--ui-carousel-thumb-gap, 1rem); }
+	/* dot(bar) — thin styled scrollbar: token defaults. --ui-carousel-dot-size is aliased
+	   to the hit height so every existing marker-group top/centering calc (overlay, bands)
+	   centers the bar's hit strip without bar-specific position rules. Declared after the
+	   dot size scale so a stray dot(sm|…|xl) never skews the bar geometry. */
+	:where(ui-card, ui-reveal, ui-media, lay-out[overflow]):where([media*="dot(bar)"]) {
+		--ui-carousel-bar-hit: 0.875rem;
+		--ui-carousel-bar-inset: 0px;
+		--ui-carousel-bar-size: 3px;
+		--ui-carousel-bar-track-size: 1px;
+		--ui-carousel-dot-size: var(--ui-carousel-bar-hit);
+	}
+	/* dot(bar) scroller arm — the anchor-name lets the marker-group size itself to the
+	   scroller via anchor-size() (implicit-anchor sizing is not reliable there). The
+	   anchor-scope is load-bearing: it confines the name to this scroller so multiple
+	   bar carousels on a page can't cross-bind to each other's anchors. Plus the native
+	   fallback: where ::scroll-marker-group is unsupported the scroller keeps its thin
+	   native scrollbar (hidden in supporting browsers by the controls-present rules in
+	   media.carousel.css / layout.css); tint its thumb with the active-dot ink */
+	:where(ui-card, ui-reveal):where([media*="dot(bar)"]) ui-media,
+	:where(ui-media, lay-out[overflow]):where([media*="dot(bar)"]) {
+		anchor-name: --ui-carousel-bar;
+		anchor-scope: --ui-carousel-bar;
+		scrollbar-color: var(--ui-carousel-dot-active, rgb(0 0 0 / 0.7)) #0000;
+	}
 	/* arrows present: base glyph vars */
 	:where(ui-card, ui-reveal, ui-media, lay-out[overflow]):where([media*="nav"]:not([media*="nav("]), [media*="nav(arw)"], [media*="nav(blw)"], [media*="nav(abv)"]) {
 		--ui-carousel-chevron-light: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23fff' stroke-width='3' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M9 18l6-6-6-6'/%3E%3C/svg%3E");
@@ -163,6 +187,14 @@
 		ui-media ui-media::scroll-button(*) { display: none; }
 		ui-media ui-media::scroll-marker-group { display: none; }
 		ui-media ui-media > :is(img, video)::scroll-marker { content: none; }
+
+		/* dot(bar) default (overlay) strip position — same value as the base rule above,
+		   restated as a standalone rule (like the band rules) so the strip's top never
+		   depends on the nested declaration; any band/in-band rule below still wins. */
+		:where(ui-card, ui-reveal):where([media*="dot(bar)"]) :where(ui-media)::scroll-marker-group,
+		:where(ui-media, lay-out[overflow]):where([media*="dot(bar)"])::scroll-marker-group {
+			top: calc(anchor(bottom) - var(--ui-carousel-overlay-gap) - var(--ui-carousel-dot-size));
+		}
 
 		/* dot shape: pill (default circle needs no rule) — applies to every slide marker */
 		:where(ui-card, ui-reveal):where([media*="dot(pll)"]) :where(ui-media) > :not(ui-chip, ui-play, ui-save, ui-sticker)::scroll-marker,
@@ -575,6 +607,47 @@
 		:where(ui-card, ui-reveal):where([media*="nav(blw)"][media*="dot(be)"][media*="arw(set)"], [media*="nav(abv)"][media*="dot(te)"][media*="arw(set)"]) :where(ui-media)::scroll-marker-group,
 		:where(ui-media, lay-out[overflow]):where([media*="nav(blw)"][media*="dot(be)"][media*="arw(set)"], [media*="nav(abv)"][media*="dot(te)"][media*="arw(set)"])::scroll-marker-group {
 			right: calc(anchor(right) + 2 * var(--ui-carousel-overlay-gap) + 2 * var(--ui-carousel-arrow-size) + var(--ui-carousel-arrow-gap));
+		}
+
+		/* ---- dot(bar) — thin styled scrollbar ---- declared LAST so the bar's geometry
+		   wins every corner/band/in-band alignment rule above (equal 0-specificity, source
+		   order). The marker-group stretches across the container as one continuous
+		   hairline; every marker is an invisible flex segment of it, and :target-current
+		   paints its stretch thicker in the active-dot ink — the "thumb" (length = 1/N).
+		   The whole track is click-to-jump and keyboard-focusable. The existing top/centering
+		   rules place the strip (the hit height is aliased into --ui-carousel-dot-size above);
+		   horizontal carousels only — axis(y) keeps its dot column. */
+		:where(ui-card, ui-reveal):where([media*="dot(bar)"]) :where(ui-media)::scroll-marker-group,
+		:where(ui-media, lay-out[overflow]):where([media*="dot(bar)"])::scroll-marker-group {
+			block-size: var(--ui-carousel-bar-hit, 0.875rem);
+			gap: 0;
+			/* the markers are flex: 1 1 0 — the group needs an explicit inline-size or it
+			   shrink-wraps to 0. Sized to the scroller via its --ui-carousel-bar anchor-name
+			   (implicit-anchor sizing is unreliable); position-anchor also makes it the
+			   default anchor, so the unnamed anchor() top/centering rules above keep working */
+			inline-size: calc(anchor-size(--ui-carousel-bar inline) - 2 * var(--ui-carousel-bar-inset, 0px));
+			inset-inline: auto;
+			justify-self: anchor-center;
+			position-anchor: --ui-carousel-bar;
+		}
+		:where(ui-card, ui-reveal):where([media*="dot(bar)"]) :where(ui-media) > :not(ui-chip, ui-play, ui-save, ui-sticker)::scroll-marker,
+		:where(ui-media, lay-out[overflow]):where([media*="dot(bar)"]) > :not(ui-chip, ui-play, ui-save, ui-sticker)::scroll-marker {
+			background: linear-gradient(var(--ui-carousel-dot-bg) 0 0) no-repeat center / 100% var(--ui-carousel-bar-track-size, 1px);
+			block-size: 100%;
+			border: 0;
+			border-radius: 0;
+			flex: 1 1 0;
+			inline-size: auto;
+		}
+		:where(ui-card, ui-reveal):where([media*="dot(bar)"]) :where(ui-media) > :not(ui-chip, ui-play, ui-save, ui-sticker)::scroll-marker:target-current,
+		:where(ui-media, lay-out[overflow]):where([media*="dot(bar)"]) > :not(ui-chip, ui-play, ui-save, ui-sticker)::scroll-marker:target-current {
+			background: linear-gradient(var(--ui-carousel-dot-active) 0 0) no-repeat center / 100% var(--ui-carousel-bar-size, 3px);
+		}
+		/* segments are visually seamless, so keyboard focus needs its own ring */
+		:where(ui-card, ui-reveal):where([media*="dot(bar)"]) :where(ui-media) > :not(ui-chip, ui-play, ui-save, ui-sticker)::scroll-marker:focus-visible,
+		:where(ui-media, lay-out[overflow]):where([media*="dot(bar)"]) > :not(ui-chip, ui-play, ui-save, ui-sticker)::scroll-marker:focus-visible {
+			outline: var(--ring-width, 2px) solid var(--ring-color, currentColor);
+			outline-offset: calc(-1 * var(--ring-width, 2px));
 		}
 	}
 

--- a/ui/card/carousel.md
+++ b/ui/card/carousel.md
@@ -169,6 +169,7 @@ A group can also hold full **`<ui-card>`s** — standard (content below) or laye
 | *(default)* | Circular dots (no token needed) |
 | `dot(pll)` | Rounded-rect pills; the active pill **fills L→R** over the autoplay duration as a timer hint |
 | `dot(hyb)` | **Hybrid** — markers stay circle dots; the active one morphs into a pill and runs the same fill timer as `dot(pll)` |
+| `dot(bar)` | **Thin styled scrollbar** — one continuous hairline track spanning the container; the current slide's stretch renders thicker in the active ink (the thumb, 1/N of the width). Click-to-jump + keyboard-navigable. See [Styled scrollbar](#styled-scrollbar--dotbar) |
 | `dot(lgt)` `dot(drk)` | Ink — light / dark (`bg` + active). `nav(blw)`/`nav(abv)` default to dark |
 | `dot(sm)` `dot(md)` `dot(lg)` `dot(xl)` | Size (`md` = default) — one scale for dots, pills **and** thumbnails, so `dot(tmb) dot(lg)` = large thumbnails |
 | **In a band** — `dot(bs/bc/be)` (below) · `dot(ts/tc/te)` (above) | **Position within a band** — the row is locked by `nav(blw)`/`nav(abv)`, so the cell's inline letter aligns the dots: start / center (default) / end. Start/end clear the arrow on that side (or the `arw(set)` pair). |
@@ -196,6 +197,37 @@ active thumb runs a bottom **timer** stripe synced to `--ui-media-autoplay` — 
 **autoplay** is running (`ui-media.js` turns it on via `--ui-media-thumb-timer-name`; it's off
 in pure CSS). (The URL uses a custom property today; it swaps to typed
 `attr(data-thumb type(<image>))` once that's Baseline.)
+
+### Styled scrollbar — `dot(bar)`
+
+Turn the marker-group into a **thin scrollbar**: a hairline track across the full
+container width, with the current slide's segment drawn thicker in the active-dot
+ink — the thumb. Every marker becomes an invisible, equal-width segment of the
+track, so the thumb is automatically **1/N of the width**, clicking anywhere on
+the track snaps to that slide, and the segments stay keyboard-focusable
+(a focused segment shows a ring).
+
+```html
+<!-- overlaid on the media (light ink) -->
+<ui-media media="asr(16/9) nav dot(bar)"> … </ui-media>
+
+<!-- the listing pattern: arrows top-right, bar in a band below (dark ink) -->
+<lay-out md="columns(3)" overflow media="nav arw(abv) arw(set) dot(bar) dot(blw)"> … </lay-out>
+```
+
+- **Ink** follows the dot tokens — track = `--ui-carousel-dot-bg`, thumb =
+  `--ui-carousel-dot-active` — so `dot(lgt)`/`dot(drk)` and the automatic dark
+  flip in `nav(blw)`/`dot(blw)`/`nav(abv)` bands just work.
+- **Geometry tokens**: `--ui-carousel-bar-size` (thumb thickness, `3px`),
+  `--ui-carousel-bar-track-size` (track thickness, `1px`), `--ui-carousel-bar-hit`
+  (clickable strip height, `0.875rem`), `--ui-carousel-bar-inset` (inline inset
+  from the container edges, `0px`).
+- **Placement**: overlaid at the media's block-end by default (like dots); use the
+  band atoms (`dot(blw)`, `nav(blw)`, …) to move it under the media. Horizontal
+  carousels only — `axis(y)` keeps its dot column.
+- **Fallback**: where `::scroll-marker-group` is unsupported, the scroller keeps
+  its **native thin scrollbar**, tinted via `scrollbar-color` with the active-dot
+  ink — still thin, still interactive.
 
 ### `load()` — image/video loading (JS-applied)
 

--- a/ui/card/media.carousel.html
+++ b/ui/card/media.carousel.html
@@ -267,6 +267,59 @@
 		</ui-card>
 	</lay-out>
 
+	<h2>Styled scrollbar — <code>dot(bar)</code></h2>
+	<p><code>dot(bar)</code> turns the markers into a <strong>thin scrollbar</strong>: one continuous hairline track spanning the container, with the current slide's stretch drawn thicker in the active ink — the thumb. The whole track is click-to-jump (each invisible segment is a scroll marker) and keyboard-navigable. Ink follows the dot tokens (<code>dot(lgt)</code>/<code>dot(drk)</code>, band flips); tune with <code>--ui-carousel-bar-size</code> / <code>--ui-carousel-bar-track-size</code> / <code>--ui-carousel-bar-inset</code>. Overlaid on the media by default; put it in a band with <code>dot(blw)</code>. Where <code>::scroll-marker-group</code> is unsupported it degrades to a tinted native thin scrollbar.</p>
+	<lay-out md="columns(2)">
+		<ui-card variant="col" media="asr(4/3) nav dot(bar)" content="scl(sm)">
+			<cq-box><ui-media><img src="/assets/images/finance.png" alt=""><img src="/assets/images/river.png" alt=""><img src="/assets/images/mindfulness.png" alt=""><img src="/assets/images/world.png" alt=""></ui-media>
+			<ui-content><small data-part="eyebrow">nav dot(bar)</small><h2 data-part="headline">Bar on the media</h2></ui-content></cq-box>
+		</ui-card>
+		<ui-card variant="col" media="asr(4/3) nav dot(bar) dot(blw)" content="scl(sm)">
+			<cq-box><ui-media><img src="/assets/images/hubble.png" alt=""><img src="/assets/images/quantum.png" alt=""><img src="/assets/images/websummit.png" alt=""><img src="/assets/images/popovers.png" alt=""></ui-media>
+			<ui-content><small data-part="eyebrow">nav dot(bar) dot(blw)</small><h2 data-part="headline">Bar in a band below</h2></ui-content></cq-box>
+		</ui-card>
+	</lay-out>
+	<h3>Card row with arrows above, bar below — <code>arw(abv) arw(set) dot(bar) dot(blw)</code></h3>
+	<p>The classic listing-carousel pattern: a <code>&lt;lay-out overflow&gt;</code> row of cards with the <strong>arrow pair top-right</strong> (<code>arw(abv) arw(set)</code>) and the <strong>thin scrollbar underneath</strong> (<code>dot(bar) dot(blw)</code>).</p>
+	<lay-out bleed xs="pi(1)" md="columns(2)" lg="columns(3)" overflow="preview-lg" media="nav arw(abv) arw(set) dot(bar) dot(blw)">
+		<ui-card variant="ovr(bl) rds(lg)" media="asr(3/4) scm" content="scl(sm) pad(lg)">
+			<cq-box>
+				<ui-media><img src="/assets/images/gastronomy.png" alt=""></ui-media>
+				<ui-content><small data-part="eyebrow">Fredagsrock</small><h3 data-part="headline">Gastronomy live</h3><p data-part="summary">31. juli kl. 22.00</p><nav data-part="actions"><a class="ui-button" href="#">Køb billet</a></nav></ui-content>
+			</cq-box>
+		</ui-card>
+		<ui-card variant="ovr(bl) rds(lg)" media="asr(3/4) scm" content="scl(sm) pad(lg)">
+			<cq-box>
+				<ui-media><img src="/assets/images/websummit.png" alt=""></ui-media>
+				<ui-content><small data-part="eyebrow">Fredagsrock</small><h3 data-part="headline">Web Summit</h3><p data-part="summary">7. august kl. 19.00</p><nav data-part="actions"><a class="ui-button" href="#">Køb billet</a></nav></ui-content>
+			</cq-box>
+		</ui-card>
+		<ui-card variant="ovr(bl) rds(lg)" media="asr(3/4) scm" content="scl(sm) pad(lg)">
+			<cq-box>
+				<ui-media><img src="/assets/images/hubble.png" alt=""></ui-media>
+				<ui-content><small data-part="eyebrow">Fredagsrock</small><h3 data-part="headline">Deep Field</h3><p data-part="summary">7. august kl. 22.00</p><nav data-part="actions"><a class="ui-button" href="#">Køb billet</a></nav></ui-content>
+			</cq-box>
+		</ui-card>
+		<ui-card variant="ovr(bl) rds(lg)" media="asr(3/4) scm" content="scl(sm) pad(lg)">
+			<cq-box>
+				<ui-media><img src="/assets/images/river.png" alt=""></ui-media>
+				<ui-content><small data-part="eyebrow">Fredagsrock</small><h3 data-part="headline">Downstream</h3><p data-part="summary">14. august kl. 19.00</p><nav data-part="actions"><a class="ui-button" href="#">Køb billet</a></nav></ui-content>
+			</cq-box>
+		</ui-card>
+		<ui-card variant="ovr(bl) rds(lg)" media="asr(3/4) scm" content="scl(sm) pad(lg)">
+			<cq-box>
+				<ui-media><img src="/assets/images/quantum.png" alt=""></ui-media>
+				<ui-content><small data-part="eyebrow">Fredagsrock</small><h3 data-part="headline">Entangled</h3><p data-part="summary">14. august kl. 22.00</p><nav data-part="actions"><a class="ui-button" href="#">Køb billet</a></nav></ui-content>
+			</cq-box>
+		</ui-card>
+		<ui-card variant="ovr(bl) rds(lg)" media="asr(3/4) scm" content="scl(sm) pad(lg)">
+			<cq-box>
+				<ui-media><img src="/assets/images/mindfulness.png" alt=""></ui-media>
+				<ui-content><small data-part="eyebrow">Fredagsrock</small><h3 data-part="headline">Stillness</h3><p data-part="summary">21. august kl. 19.00</p><nav data-part="actions"><a class="ui-button" href="#">Køb billet</a></nav></ui-content>
+			</cq-box>
+		</ui-card>
+	</lay-out>
+
 	<hr>
 	<!-- ════════════════════════════════════════════════════════════
 	     5 · THUMBNAILS — dot(tmb)

--- a/ui/card/media.carousel.md
+++ b/ui/card/media.carousel.md
@@ -203,6 +203,29 @@ descendant rules (0,0,1). The carousel-specific **control suppression** stays he
   (overlay), inset by `--ui-media-marker-inset` (defaults to the overlay gap; `dot(tmb)`
   bumps it to `1rem`). In `axis(y)` the corner rail stacks vertically. Default (no corner
   token) stays bottom-centered.
+- **`dot(bar)` — segmented thin scrollbar.** The marker-group becomes one full-width
+  strip: every marker is an invisible `flex: 1 1 0` segment painted as a centered
+  hairline (`linear-gradient` track, `100% × --ui-carousel-bar-track-size`), and
+  `:target-current` repaints its stretch thicker (`--ui-carousel-bar-size`) in the
+  active-dot ink — the "thumb", 1/N wide, snapping segment-to-segment. Track clicks
+  and keyboard focus are native marker behavior; a focused segment shows an inset ring.
+  **Sizing** is the subtle part: the `flex: 1 1 0` markers give the group no intrinsic
+  width and opposing `left`/`right` anchor insets don't reliably stretch an
+  anchor-positioned pseudo, so the scroller declares `anchor-name: --ui-carousel-bar`
+  and the group sizes itself with `inline-size: calc(anchor-size(--ui-carousel-bar
+  inline) - 2 * --ui-carousel-bar-inset)` (+ `position-anchor` to the same name, so the
+  unnamed `anchor()` top/centering rules keep resolving). The scroller's matching
+  `anchor-scope: --ui-carousel-bar` is **load-bearing** — without it, multiple bar
+  carousels on one page cross-bind to each other's anchors. The hit-strip height
+  (`--ui-carousel-bar-hit`) is aliased into `--ui-carousel-dot-size` on the host arm so
+  every existing group top/centering calc (overlay + bands) centers the bar without
+  bar-specific position rules; the geometry block is declared last inside the gate so
+  it wins the corner/in-band alignment rules on source order. Horizontal only; outside
+  the `@supports` gate the host arm tints the native thin scrollbar via
+  `scrollbar-color` as the fallback. (A continuous gliding thumb is possible —
+  scroll-driven animation on the scroller + an inherited custom property, since
+  `scroll(nearest)` does **not** resolve from the group's own box — but the segmented
+  form needs no timeline at all.)
 
 ## Arrows
 


### PR DESCRIPTION
## What

A fourth `dot()` marker shape alongside `pll`/`hyb`/`tmb`: **`dot(bar)`** turns the `::scroll-marker-group` into a thin styled scrollbar — one continuous hairline track spanning the container, with the current slide's stretch painted thicker in the active-dot ink (the thumb, automatically 1/N wide). Replicates the classic listing-carousel pattern (arrow pair top-right, thin scrollbar underneath) in pure CSS.

```html
<!-- the listing pattern -->
<lay-out md="columns(3)" overflow media="nav arw(abv) arw(set) dot(bar) dot(blw)"> … </lay-out>

<!-- overlaid on the media -->
<ui-media media="asr(16/9) nav dot(bar)"> … </ui-media>
```

## How

- Every slide's `::scroll-marker` becomes an invisible `flex: 1 1 0` segment of the full-width group, painted as a centered hairline (`100% × --ui-carousel-bar-track-size`); `:target-current` repaints its stretch at `--ui-carousel-bar-size` in the active ink. Segments are real scroll markers, so the whole track is **click-to-jump and keyboard-focusable** (focused segment shows a `--ring-*` outline).
- **Ink derives from the dot tokens** (track = `--ui-carousel-dot-bg`, thumb = `--ui-carousel-dot-active`), so `dot(lgt)`/`dot(drk)` and the automatic dark flip in `nav(blw)`/`dot(blw)`/`nav(abv)` bands work with zero new rules.
- **Sizing**: the flex markers give the group no intrinsic width and opposing `left`/`right` anchor insets don't reliably stretch the anchor-positioned pseudo, so the scroller declares `anchor-name: --ui-carousel-bar` and the group sizes itself via `anchor-size(--ui-carousel-bar inline)`. The scroller's matching `anchor-scope` is load-bearing — without it, multiple bar carousels on one page cross-bind to each other's anchors.
- **Fallback** outside the `@supports (scroll-marker-group: after)` gate: the scroller keeps its native thin scrollbar, tinted via `scrollbar-color` with the active-dot ink.
- New tokens: `--ui-carousel-bar-size` (3px), `--ui-carousel-bar-track-size` (1px), `--ui-carousel-bar-hit` (0.875rem clickable strip), `--ui-carousel-bar-inset` (0).
- Horizontal carousels only for now; `axis(y)` keeps its dot column.

## Changes

- `ui/base/carousel.css` — token defaults + scroller arm (anchor-name/scope, scrollbar-color fallback) outside the gate; bar geometry/paint/focus rules declared last inside the gate (0-specificity `:where()`, source-order overrides per the file's invariant)
- `ui/card/media.carousel.html` — new "Styled scrollbar" demo section: overlay + band card examples and the listing-pattern card row
- `ui/card/carousel.md` — `dot(bar)` token reference + Styled scrollbar section
- `ui/card/media.carousel.md` — internals note on the segmented-marker technique and the anchor sizing/scoping

## Verification

Driven headless (Chromium) against the live demo page: bar renders in all three placements (overlay on media, band below in a card, full-width under a `lay-out overflow` row), the thumb segment tracks the snap target at start/mid/end scroll, and clicking the track end jumps the scroller. Regression screenshots of the dots/bands/thumbnails sections are unchanged — every new rule is `[media*="dot(bar)"]`-scoped.

Trade-offs (by design): thumb steps segment-to-segment on snap (a continuous scroll-driven glide was prototyped and can be layered on later); thumb length is 1/N slides, not the visible/total ratio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YFrjsvHb2qgWcFnsTRert8

---
_Generated by [Claude Code](https://claude.ai/code/session_01YFrjsvHb2qgWcFnsTRert8)_