### PR TITLE
feat(carousel): dot(bar) width scale via the repurposed dot size atoms

### DIFF
--- a/ui/base/carousel.css
+++ b/ui/base/carousel.css
@@ -58,13 +58,22 @@
 	/* dot(bar) — thin styled scrollbar: token defaults. --ui-carousel-dot-size is aliased
 	   to the hit height so every existing marker-group top/centering calc (overlay, bands)
 	   centers the bar's hit strip without bar-specific position rules. Declared after the
-	   dot size scale so a stray dot(sm|…|xl) never skews the bar geometry. */
+	   dot size scale, which the bar REPURPOSES: with dot(bar), the size atoms set the bar's
+	   inline span as a fraction of the scroller — sm 33% · md 50% · lg 75% (default) ·
+	   xl 100% (a fraction, not a percentage: it multiplies anchor-size() in a calc).
+	   The nested atoms stay :where()-wrapped to keep the file's 0-0-0 specificity. */
 	:where(ui-card, ui-reveal, ui-media, lay-out[overflow]):where([media*="dot(bar)"]) {
 		--ui-carousel-bar-hit: 0.875rem;
 		--ui-carousel-bar-inset: 0px;
 		--ui-carousel-bar-size: 3px;
+		--ui-carousel-bar-span: 0.75;
 		--ui-carousel-bar-track-size: 1px;
 		--ui-carousel-dot-size: var(--ui-carousel-bar-hit);
+
+		&:where([media*="dot(sm)"]) { --ui-carousel-bar-span: 0.33; }
+		&:where([media*="dot(md)"]) { --ui-carousel-bar-span: 0.5; }
+		&:where([media*="dot(lg)"]) { --ui-carousel-bar-span: 0.75; }
+		&:where([media*="dot(xl)"]) { --ui-carousel-bar-span: 1; }
 	}
 	/* dot(bar) scroller arm — the anchor-name lets the marker-group size itself to the
 	   scroller via anchor-size() (implicit-anchor sizing is not reliable there). The
@@ -624,8 +633,10 @@
 			/* the markers are flex: 1 1 0 — the group needs an explicit inline-size or it
 			   shrink-wraps to 0. Sized to the scroller via its --ui-carousel-bar anchor-name
 			   (implicit-anchor sizing is unreliable); position-anchor also makes it the
-			   default anchor, so the unnamed anchor() top/centering rules above keep working */
-			inline-size: calc(anchor-size(--ui-carousel-bar inline) - 2 * var(--ui-carousel-bar-inset, 0px));
+			   default anchor, so the unnamed anchor() top/centering rules above keep working.
+			   --ui-carousel-bar-span (a fraction, from the repurposed dot size scale) then
+			   scales the strip; anchor-center keeps a partial-span strip centered. */
+			inline-size: calc((anchor-size(--ui-carousel-bar inline) - 2 * var(--ui-carousel-bar-inset, 0px)) * var(--ui-carousel-bar-span, 1));
 			inset-inline: auto;
 			justify-self: anchor-center;
 			position-anchor: --ui-carousel-bar;
@@ -648,6 +659,21 @@
 		:where(ui-media, lay-out[overflow]):where([media*="dot(bar)"]) > :not(ui-chip, ui-play, ui-save, ui-sticker)::scroll-marker:focus-visible {
 			outline: var(--ring-width, 2px) solid var(--ring-color, currentColor);
 			outline-offset: calc(-1 * var(--ring-width, 2px));
+		}
+		/* partial-span alignment — centered by default (anchor-center above); the cell's
+		   inline letter pins the strip to an edge instead (bs/ts = start, be/te = end).
+		   Vertical placement still comes from the corner/band rules earlier in the file. */
+		:where(ui-card, ui-reveal):where([media*="dot(bar)"]:is([media*="dot(bs)"], [media*="dot(ts)"])) :where(ui-media)::scroll-marker-group,
+		:where(ui-media, lay-out[overflow]):where([media*="dot(bar)"]:is([media*="dot(bs)"], [media*="dot(ts)"]))::scroll-marker-group {
+			justify-self: start;
+			left: calc(anchor(left) + var(--ui-carousel-bar-inset, 0px));
+			right: auto;
+		}
+		:where(ui-card, ui-reveal):where([media*="dot(bar)"]:is([media*="dot(be)"], [media*="dot(te)"])) :where(ui-media)::scroll-marker-group,
+		:where(ui-media, lay-out[overflow]):where([media*="dot(bar)"]:is([media*="dot(be)"], [media*="dot(te)"]))::scroll-marker-group {
+			justify-self: end;
+			left: auto;
+			right: calc(anchor(right) + var(--ui-carousel-bar-inset, 0px));
 		}
 	}
 

--- a/ui/card/carousel.md
+++ b/ui/card/carousel.md
@@ -171,7 +171,7 @@ A group can also hold full **`<ui-card>`s** — standard (content below) or laye
 | `dot(hyb)` | **Hybrid** — markers stay circle dots; the active one morphs into a pill and runs the same fill timer as `dot(pll)` |
 | `dot(bar)` | **Thin styled scrollbar** — one continuous hairline track spanning the container; the current slide's stretch renders thicker in the active ink (the thumb, 1/N of the width). Click-to-jump + keyboard-navigable. See [Styled scrollbar](#styled-scrollbar--dotbar) |
 | `dot(lgt)` `dot(drk)` | Ink — light / dark (`bg` + active). `nav(blw)`/`nav(abv)` default to dark |
-| `dot(sm)` `dot(md)` `dot(lg)` `dot(xl)` | Size (`md` = default) — one scale for dots, pills **and** thumbnails, so `dot(tmb) dot(lg)` = large thumbnails |
+| `dot(sm)` `dot(md)` `dot(lg)` `dot(xl)` | Size (`md` = default) — one scale for dots, pills **and** thumbnails, so `dot(tmb) dot(lg)` = large thumbnails. With `dot(bar)` the scale sets the bar **width** instead: 33% · 50% · 75% (`lg` = default) · 100% |
 | **In a band** — `dot(bs/bc/be)` (below) · `dot(ts/tc/te)` (above) | **Position within a band** — the row is locked by `nav(blw)`/`nav(abv)`, so the cell's inline letter aligns the dots: start / center (default) / end. Start/end clear the arrow on that side (or the `arw(set)` pair). |
 | `dot(bc)` | `axis(y)`: dots centered at the **bottom** (e.g. with a pill timer) |
 | `dot(non)` | **No dots** (keeps arrows) — e.g. an arrows-only `nav(blw)`/`nav(abv)` band |
@@ -211,17 +211,23 @@ the track snaps to that slide, and the segments stay keyboard-focusable
 <!-- overlaid on the media (light ink) -->
 <ui-media media="asr(16/9) nav dot(bar)"> … </ui-media>
 
-<!-- the listing pattern: arrows top-right, bar in a band below (dark ink) -->
-<lay-out md="columns(3)" overflow media="nav arw(abv) arw(set) dot(bar) dot(blw)"> … </lay-out>
+<!-- the listing pattern: arrows top-right, full-width bar in a band below (dark ink) -->
+<lay-out md="columns(3)" overflow media="nav arw(abv) arw(set) dot(bar) dot(xl) dot(blw)"> … </lay-out>
 ```
 
+- **Width** comes from the repurposed size scale: `dot(sm)` 33% · `dot(md)` 50% ·
+  `dot(lg)` 75% (**default**, no token needed) · `dot(xl)` 100%. A partial-width
+  bar is centered; pin it to an edge with the cell's inline letter —
+  `dot(bs)`/`dot(ts)` = start, `dot(be)`/`dot(te)` = end. Fine-tune with
+  `--ui-carousel-bar-span` (a **fraction**, e.g. `0.6` — it multiplies the
+  scroller's `anchor-size()`, so it can't be a percentage).
 - **Ink** follows the dot tokens — track = `--ui-carousel-dot-bg`, thumb =
   `--ui-carousel-dot-active` — so `dot(lgt)`/`dot(drk)` and the automatic dark
   flip in `nav(blw)`/`dot(blw)`/`nav(abv)` bands just work.
-- **Geometry tokens**: `--ui-carousel-bar-size` (thumb thickness, `3px`),
-  `--ui-carousel-bar-track-size` (track thickness, `1px`), `--ui-carousel-bar-hit`
-  (clickable strip height, `0.875rem`), `--ui-carousel-bar-inset` (inline inset
-  from the container edges, `0px`).
+- **Thickness / geometry tokens**: `--ui-carousel-bar-size` (thumb thickness,
+  `3px`), `--ui-carousel-bar-track-size` (track thickness, `1px`) — bump these
+  for a heavier bar; `--ui-carousel-bar-hit` (clickable strip height, `0.875rem`),
+  `--ui-carousel-bar-inset` (inline inset from the container edges, `0px`).
 - **Placement**: overlaid at the media's block-end by default (like dots); use the
   band atoms (`dot(blw)`, `nav(blw)`, …) to move it under the media. Horizontal
   carousels only — `axis(y)` keeps its dot column.

--- a/ui/card/media.carousel.html
+++ b/ui/card/media.carousel.html
@@ -268,7 +268,7 @@
 	</lay-out>
 
 	<h2>Styled scrollbar — <code>dot(bar)</code></h2>
-	<p><code>dot(bar)</code> turns the markers into a <strong>thin scrollbar</strong>: one continuous hairline track spanning the container, with the current slide's stretch drawn thicker in the active ink — the thumb. The whole track is click-to-jump (each invisible segment is a scroll marker) and keyboard-navigable. Ink follows the dot tokens (<code>dot(lgt)</code>/<code>dot(drk)</code>, band flips); tune with <code>--ui-carousel-bar-size</code> / <code>--ui-carousel-bar-track-size</code> / <code>--ui-carousel-bar-inset</code>. Overlaid on the media by default; put it in a band with <code>dot(blw)</code>. Where <code>::scroll-marker-group</code> is unsupported it degrades to a tinted native thin scrollbar.</p>
+	<p><code>dot(bar)</code> turns the markers into a <strong>thin scrollbar</strong>: one continuous hairline track, with the current slide's stretch drawn thicker in the active ink — the thumb. The whole track is click-to-jump (each invisible segment is a scroll marker) and keyboard-navigable. With <code>dot(bar)</code> the size scale sets the bar's <strong>width</strong>: <code>dot(sm)</code> 33% · <code>dot(md)</code> 50% · <code>dot(lg)</code> 75% (default) · <code>dot(xl)</code> 100%. A partial bar centers; the cell's inline letter pins it to an edge (<code>dot(bs)</code>/<code>dot(be)</code>). Ink follows the dot tokens (<code>dot(lgt)</code>/<code>dot(drk)</code>, band flips); thickness via <code>--ui-carousel-bar-size</code> / <code>--ui-carousel-bar-track-size</code>. Overlaid on the media by default; put it in a band with <code>dot(blw)</code>. Where <code>::scroll-marker-group</code> is unsupported it degrades to a tinted native thin scrollbar.</p>
 	<lay-out md="columns(2)">
 		<ui-card variant="col" media="asr(4/3) nav dot(bar)" content="scl(sm)">
 			<cq-box><ui-media><img src="/assets/images/finance.png" alt=""><img src="/assets/images/river.png" alt=""><img src="/assets/images/mindfulness.png" alt=""><img src="/assets/images/world.png" alt=""></ui-media>
@@ -279,9 +279,28 @@
 			<ui-content><small data-part="eyebrow">nav dot(bar) dot(blw)</small><h2 data-part="headline">Bar in a band below</h2></ui-content></cq-box>
 		</ui-card>
 	</lay-out>
+	<h3>Width — <code>dot(sm|md|lg|xl)</code> · edge alignment</h3>
+	<lay-out md="columns(2)">
+		<ui-card variant="col" media="asr(4/3) nav dot(bar) dot(sm) dot(blw)" content="scl(sm)">
+			<cq-box><ui-media><img src="/assets/images/gastronomy.png" alt=""><img src="/assets/images/brewandbean.png" alt=""><img src="/assets/images/aurasoundpro.png" alt=""></ui-media>
+			<ui-content><small data-part="eyebrow">dot(bar) dot(sm)</small><h2 data-part="headline">Short bar — 33%</h2></ui-content></cq-box>
+		</ui-card>
+		<ui-card variant="col" media="asr(4/3) nav dot(bar) dot(md) dot(blw)" content="scl(sm)">
+			<cq-box><ui-media><img src="/assets/images/mindfulness.png" alt=""><img src="/assets/images/world.png" alt=""><img src="/assets/images/finance.png" alt=""></ui-media>
+			<ui-content><small data-part="eyebrow">dot(bar) dot(md)</small><h2 data-part="headline">Half width — 50%</h2></ui-content></cq-box>
+		</ui-card>
+		<ui-card variant="col" media="asr(4/3) nav dot(bar) dot(xl) dot(blw)" content="scl(sm)">
+			<cq-box><ui-media><img src="/assets/images/ergochair.png" alt=""><img src="/assets/images/slimfold.png" alt=""><img src="/assets/images/cutmaster.png" alt=""></ui-media>
+			<ui-content><small data-part="eyebrow">dot(bar) dot(xl)</small><h2 data-part="headline">Full width — 100%</h2></ui-content></cq-box>
+		</ui-card>
+		<ui-card variant="col" media="asr(4/3) nav dot(bar) dot(sm) dot(be) dot(blw)" content="scl(sm)">
+			<cq-box><ui-media><img src="/assets/images/river.png" alt=""><img src="/assets/images/popovers.png" alt=""><img src="/assets/images/government.png" alt=""></ui-media>
+			<ui-content><small data-part="eyebrow">dot(bar) dot(sm) dot(be)</small><h2 data-part="headline">Short bar, inline-end</h2></ui-content></cq-box>
+		</ui-card>
+	</lay-out>
 	<h3>Card row with arrows above, bar below — <code>arw(abv) arw(set) dot(bar) dot(blw)</code></h3>
 	<p>The classic listing-carousel pattern: a <code>&lt;lay-out overflow&gt;</code> row of cards with the <strong>arrow pair top-right</strong> (<code>arw(abv) arw(set)</code>) and the <strong>thin scrollbar underneath</strong> (<code>dot(bar) dot(blw)</code>).</p>
-	<lay-out bleed xs="pi(1)" md="columns(2)" lg="columns(3)" overflow="preview-lg" media="nav arw(abv) arw(set) dot(bar) dot(blw)">
+	<lay-out bleed xs="pi(1)" md="columns(2)" lg="columns(3)" overflow="preview-lg" media="nav arw(abv) arw(set) dot(bar) dot(xl) dot(blw)">
 		<ui-card variant="ovr(bl) rds(lg)" media="asr(3/4) scm" content="scl(sm) pad(lg)">
 			<cq-box>
 				<ui-media><img src="/assets/images/gastronomy.png" alt=""></ui-media>

--- a/ui/card/media.carousel.md
+++ b/ui/card/media.carousel.md
@@ -222,7 +222,14 @@ descendant rules (0,0,1). The carousel-specific **control suppression** stays he
   bar-specific position rules; the geometry block is declared last inside the gate so
   it wins the corner/in-band alignment rules on source order. Horizontal only; outside
   the `@supports` gate the host arm tints the native thin scrollbar via
-  `scrollbar-color` as the fallback. (A continuous gliding thumb is possible —
+  `scrollbar-color` as the fallback. **Width**: with `dot(bar)` the dot size scale is
+  repurposed — the atoms set `--ui-carousel-bar-span` (sm .33 · md .5 · lg .75 =
+  default · xl 1), a **fraction** that multiplies the `anchor-size()` term in the
+  group's `inline-size` calc (fraction, not percentage: `calc(<length> * <percentage>)`
+  is invalid). A partial-span strip stays centered via `justify-self: anchor-center`;
+  the cell's inline letter re-pins it (`dot(bs)`/`dot(ts)` → `left: anchor(left)`,
+  `dot(be)`/`dot(te)` → `right: anchor(right)`) — rules declared after the geometry
+  block so they win on source order. (A continuous gliding thumb is possible —
   scroll-driven animation on the scroller + an inherited custom property, since
   `scroll(nearest)` does **not** resolve from the group's own box — but the segmented
   form needs no timeline at all.)


### PR DESCRIPTION
## What

With `dot(bar)`, the dot size scale now sets the bar's **inline width** instead of the (inert) dot geometry: `dot(sm)` 33% · `dot(md)` 50% · `dot(lg)` 75% (**the new default**, no token needed) · `dot(xl)` 100%.

- A partial-width bar centers under the media; the cell's inline letter pins it to an edge (`dot(bs)`/`dot(ts)` = start, `dot(be)`/`dot(te)` = end) — no new vocabulary.
- Fine-tuning via `--ui-carousel-bar-span`, a **fraction** that multiplies the scroller's `anchor-size()` (a percentage can't multiply a length in `calc()`).
- Thickness stays custom-property-only: `--ui-carousel-bar-size` / `--ui-carousel-bar-track-size`.
- The scale atoms are nested inside the `dot(bar)` block with `&:where(…)`, preserving the file's 0-0-0 specificity invariant.

## ⚠️ Default change

The bar default narrows from 100% → **75%**. Existing `dot(bar)` usage wanting edge-to-edge needs `dot(xl)` — the demo listing row and the `carousel.md` example are updated accordingly.

## Verification

Headless Chromium against the live demo page: all four widths step correctly and stay centered, `dot(be)` pins the short bar inline-end, the listing row is full-width again via `dot(xl)`, thumb tracking + click-to-jump unchanged, and the dots/pills/thumbnails sections are unaffected (every new rule requires `dot(bar)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YFrjsvHb2qgWcFnsTRert8

---
_Generated by [Claude Code](https://claude.ai/code/session_01YFrjsvHb2qgWcFnsTRert8)_