### PR TITLE
stagger: per-child index/step overrides via typed attr() + semi/full fade opacity

### DIFF
--- a/ui/accordion/index.html
+++ b/ui/accordion/index.html
@@ -811,6 +811,39 @@
 	</auto-morph>
 
 	<br>
+	<h2>Stagger: per-child overrides + fade opacity</h2>
+	<p>Per-child overrides on the shared stagger engine, read via typed <code>attr()</code>: <code>data-stagger-index</code> reorders the cascade, <code>data-stagger-step</code> paces a single child, and <code>data-stagger="fde semi"</code> fades in element by element from half opacity.</p>
+
+	<ui-accordion group="accordion-overrides" variant="bordered divided rounded">
+		<cq-box>
+			<details name="accordion-overrides" open>
+				<summary>Reordered cascade (2, 1, 3)<ui-icon type="plus-minus"></ui-icon></summary>
+				<div data-stagger>
+					<p data-stagger-index="2">Second to appear — although it is the first paragraph in the DOM, its <code>data-stagger-index="2"</code> puts it in the middle of the cascade.</p>
+					<p data-stagger-index="1">First to appear — <code>data-stagger-index="1"</code> pulls it ahead of the paragraph above it.</p>
+					<p data-stagger-index="3">Third to appear — <code>data-stagger-index="3"</code> keeps it last, exactly where the DOM would have put it anyway.</p>
+				</div>
+			</details>
+			<details name="accordion-overrides">
+				<summary>Per-child pace<ui-icon type="plus-minus"></ui-icon></summary>
+				<div data-stagger>
+					<p data-stagger-step="0.02s">Quick — <code>data-stagger-step="0.02s"</code> makes this child's whole delay tiny.</p>
+					<p>Default — no attribute, so this child paces off the shared <code>--stagger-step</code>.</p>
+					<p data-stagger-step="0.6s">Extremely slow — <code>data-stagger-step="0.6s"</code> scales this child's delay to 1.2s.</p>
+				</div>
+			</details>
+			<details name="accordion-overrides">
+				<summary>Fade in from half opacity<ui-icon type="plus-minus"></ui-icon></summary>
+				<div data-stagger="fde semi">
+					<p>These lines fade in one after another — no movement, just opacity.</p>
+					<p>The <code>semi</code> modifier starts them at <code>opacity: 0.5</code> instead of fully hidden.</p>
+					<p>Drop the modifier (or spell it <code>full</code>) for the default fade from <code>opacity: 0</code>.</p>
+				</div>
+			</details>
+		</cq-box>
+	</ui-accordion>
+
+	<br>
 	<p>With <code>tabs="ellipse"</code> and classes <code>tabs-fill-surface tabs-offset</code> — panels stagger with <code>data-stagger="fall"</code>:</p>
 	<auto-morph render="tabs">
 		<ui-accordion group="accordion-tabs-ellipse" class="tabs-fill-surface tabs-offset" variant="bordered divided rounded" tabs="ellipse">

--- a/ui/base/animations.css
+++ b/ui/base/animations.css
@@ -273,7 +273,7 @@
 	   on the element rule, not here). */
 	@keyframes ui-stagger-in {
 		from {
-			opacity: 0;
+			opacity: var(--_stg-op, var(--stagger-opacity, 0));
 			translate: var(--_stg-tr, 0 var(--stagger-distance, 5rem));
 			scale: var(--_stg-sc, 1);
 			filter: var(--_stg-fl, none);

--- a/ui/base/polyfills/attr-fallback.js
+++ b/ui/base/polyfills/attr-fallback.js
@@ -83,6 +83,11 @@ export const ATTR_MAP = {
 	// data-fill, not fill: the target is an <li>, where a bare attribute is invalid HTML
 	// (same reason the named palette is data-theme= there, but that needs no polyfill)
 	':is(ui-timeline, .ui-timeline, [data-part="timeline"]) > li[data-fill]': { '--ui-timeline-dot': ['data-fill', 'inherit'] },
+	// stagger per-child overrides — KEEP IN SYNC with ui/base/stagger.css
+	'[stagger-index]':      { '--_stg-i':    ['stagger-index', '1'] },
+	'[data-stagger-index]': { '--_stg-i':    ['data-stagger-index', '1'] },
+	'[stagger-step]':       { '--_stg-step': ['stagger-step', 'var(--stagger-step, 0.07s)'] },
+	'[data-stagger-step]':  { '--_stg-step': ['data-stagger-step', 'var(--stagger-step, 0.07s)'] },
 	'ui-sticker': {
 		'--ui-sticker-bg': ['fill', 'var(--color-accent)'],
 		'--ui-sticker-c': ['ink', 'hsl(0, 0%, 100%)'],

--- a/ui/base/polyfills/readme.md
+++ b/ui/base/polyfills/readme.md
@@ -7,8 +7,9 @@
 Load it on any page that uses a component reading author values from attributes —
 `ui-sticker fill=`, `ui-chip ink=`, `ui-avatar ring=`, `high-light fill=`,
 `ui-rating value=`, `mega-menu menubar-height=`, `ui-gradient-text gradient=`,
-`[data-view]`. It is a **no-op** where typed `attr()` is supported, so it is safe
-to load unconditionally.
+`[data-view]`, and the stagger per-child overrides `stagger-index=` /
+`stagger-step=` (+ their `data-` forms). It is a **no-op** where typed `attr()`
+is supported, so it is safe to load unconditionally.
 
 ---
 
@@ -19,7 +20,7 @@ duplicate and neither replaces the other — they cover **disjoint** attribute s
 
 | | `ui/base/polyfills/attr-fallback.js` | `layout/polyfills/attr-fallback.js` |
 |---|---|---|
-| Covers | component attributes — `ui-sticker fill=`, `ui-chip ink=`, `ui-avatar ring=`, `high-light fill=`, `ui-rating value=`, `mega-menu menubar-height=`, `ui-gradient-text gradient=`, `[data-view]` | `<lay-out>` attributes — exactly `bleed=`, `columns=`, `rows=`, `max-width=`, `self=`, `size=` |
+| Covers | component attributes — `ui-sticker fill=`, `ui-chip ink=`, `ui-avatar ring=`, `high-light fill=`, `ui-rating value=`, `mega-menu menubar-height=`, `ui-gradient-text gradient=`, `[data-view]`, `stagger-index=`/`stagger-step=` (+ `data-` forms) | `<lay-out>` attributes — exactly `bleed=`, `columns=`, `rows=`, `max-width=`, `self=`, `size=` |
 | Shape | ES module (documented `ATTR_MAP`, exports nothing) | IIFE body, still loaded as `type="module"` (it resolves its stylesheet via `import.meta.url`) |
 | Companion CSS | none | yes — injects `attr-fallback.css` |
 | Maps to | one CSS custom property **per selector** | one custom property **per attribute name** |
@@ -85,6 +86,20 @@ Two corollaries worth knowing:
 
 Layer 1 is not optional: a component installed on its own must not depend on an
 app-level script to be usable.
+
+The stagger overrides degrade CSS-only along exactly these two layers:
+
+- `stagger-index=` — `--_stg-i` is a **registered** `<integer>`, so in Safari/Firefox
+  both the `sibling-index()` default and the un-substituted `attr()` text fail the
+  syntax check and fall to `initial-value: 1`: a uniform cascade (`delay =
+  --stagger-begin`), which is what those browsers already get today without
+  `sibling-index()`. No `@supports` block needed — registration is the layer 1.
+- `stagger-step=` — `--_stg-step` is unregistered (registering would kill the
+  `--stagger-step` theming fallback), so its layer 1 is an explicit `@supports not
+  (transition-delay: attr(x type(<time>), 0s))` guard in `stagger.css` that resets
+  it to the default `--stagger-step`. The child cascades at the default pace, and
+  this polyfill restores the exact authored values on top — an enhancement, not
+  load-bearing.
 
 ## Adding a component to the registry
 

--- a/ui/base/stagger.css
+++ b/ui/base/stagger.css
@@ -17,7 +17,8 @@
  * cascade (the card carousel bridges its card index into it).
  * --_stg-i defaults to sibling-index(); stagger-index=/data-stagger-index= and
  * stagger-step=/data-stagger-step= override index/step per child (typed attr()).
- * Tokens: --stagger-{begin,distance,duration,easing,step} — ui/base/tokens.css.
+ * semi/full (+ ani()/crd() forms) set the from-opacity via --stagger-opacity.
+ * Tokens: --stagger-{begin,distance,duration,easing,step,opacity} — ui/base/tokens.css.
  * Docs: ui/card/docs/stagger.md.
  *
  * Two trigger adapters:
@@ -96,6 +97,14 @@
 	:where([media*="crd(blr)"])  { --_stg-crd-tr: 0 0; --_stg-crd-fl: blur(12px); }
 	:where([media*="crd(fde)"])  { --_stg-crd-tr: 0 0; }
 
+	/* fade-from-opacity modifiers — compose with any effect (docs: ui/card/docs/stagger.md) */
+	:where([stagger~="semi"], [data-stagger~="semi"]) { --_stg-op: 0.5; }
+	:where([stagger~="full"], [data-stagger~="full"]) { --_stg-op: 0; }
+	:where([media*="ani(semi)"]) { --_stg-op: 0.5; }
+	:where([media*="ani(full)"]) { --_stg-op: 0; }
+	:where([media*="crd(semi)"]) { --_stg-crd-op: 0.5; }
+	:where([media*="crd(full)"]) { --_stg-crd-op: 0; }
+
 	/* per-child index/step — defaults first, attribute readers after (source order resolves) */
 	:where([stagger], [data-stagger]) > :where(:not(cq-box)),
 	:where([stagger], [data-stagger]) > :where(cq-box) > *,
@@ -152,7 +161,7 @@
 			details[open] > :is([stagger], [data-stagger]) > :not(cq-box),
 			details[open] > :is([stagger], [data-stagger]) > cq-box > * {
 				filter: var(--_stg-fl, none);
-				opacity: 0;
+				opacity: var(--_stg-op, var(--stagger-opacity, 0));
 				scale: var(--_stg-sc, 1);
 				translate: var(--_stg-tr, 0 var(--stagger-distance, 5rem));
 			}
@@ -197,14 +206,14 @@
 		@container not scroll-state(snapped: inline) {
 			:where(ui-card[media*="stagger"], ui-reveal[media*="stagger"]) ui-media > :where(ui-slide, lay-out) > *,
 			ui-media:where([media*="stagger"]) > :where(ui-slide, lay-out) > * {
-				opacity: 0;
+				opacity: var(--_stg-crd-op, var(--stagger-opacity, 0));
 				translate: var(--_stg-crd-tr, 0 var(--stagger-distance, 5rem));
 				scale: var(--_stg-crd-sc, 1);
 				filter: var(--_stg-crd-fl, none);
 			}
 			:where(ui-card[media*="stagger"], ui-reveal[media*="stagger"]) ui-media ui-content > *,
 			ui-media:where([media*="stagger"]) ui-content > * {
-				opacity: 0;
+				opacity: var(--_stg-op, var(--stagger-opacity, 0));
 				translate: var(--_stg-tr, 0 var(--stagger-distance, 5rem));
 				scale: var(--_stg-sc, 1);
 				filter: var(--_stg-fl, none);

--- a/ui/base/stagger.css
+++ b/ui/base/stagger.css
@@ -12,10 +12,13 @@
  * box vector — own --stagger-shimmer-* tokens, own section at the bottom of this
  * file, <details> hosts only. See ui/card/docs/stagger.md § Shimmer.
  *
- * Per-child delay = --stagger-begin + (--_stg-base-i + sibling-index() - 1) * --stagger-step.
+ * Per-child delay = --stagger-begin + (--_stg-base-i + --_stg-i - 1) * --_stg-step.
  * --_stg-base-i (registered, non-inherited, initial 0) lets a host offset the
  * cascade (the card carousel bridges its card index into it).
+ * --_stg-i defaults to sibling-index(); stagger-index=/data-stagger-index= and
+ * stagger-step=/data-stagger-step= override index/step per child (typed attr()).
  * Tokens: --stagger-{begin,distance,duration,easing,step} — ui/base/tokens.css.
+ * Docs: ui/card/docs/stagger.md.
  *
  * Two trigger adapters:
  *  1. <details> hosts (ui-tabs, ui-reveal, ui-accordion, plain <details>) —
@@ -45,6 +48,13 @@
 		syntax: "<integer>";
 		inherits: false;
 		initial-value: 0;
+	}
+	/* per-child cascade index — sibling-index() or a stagger-index attribute;
+	   non-inherited so a nested stagger host starts its own cascade */
+	@property --_stg-i {
+		syntax: "<integer>";
+		inherits: false;
+		initial-value: 1;
 	}
 	/* carousel card-index carrier — inherits so a slide's cards pass their column
 	   index down to their own content (see adapter 2) */
@@ -86,6 +96,24 @@
 	:where([media*="crd(blr)"])  { --_stg-crd-tr: 0 0; --_stg-crd-fl: blur(12px); }
 	:where([media*="crd(fde)"])  { --_stg-crd-tr: 0 0; }
 
+	/* per-child index/step — defaults first, attribute readers after (source order resolves) */
+	:where([stagger], [data-stagger]) > :where(:not(cq-box)),
+	:where([stagger], [data-stagger]) > :where(cq-box) > *,
+	:where(ui-card[media*="stagger"], ui-reveal[media*="stagger"]) :where(ui-media) > :where(ui-slide, lay-out) > *,
+	:where(ui-media[media*="stagger"]) > :where(ui-slide, lay-out) > *,
+	:where(ui-card[media*="stagger"], ui-reveal[media*="stagger"]) :where(ui-media) :where(ui-content) > *,
+	:where(ui-media[media*="stagger"]) :where(ui-content) > * {
+		--_stg-i: sibling-index();
+	}
+	:where([stagger-index])      { --_stg-i: attr(stagger-index type(<integer>), sibling-index()); }
+	:where([data-stagger-index]) { --_stg-i: attr(data-stagger-index type(<integer>), sibling-index()); }
+	:where([stagger-step])       { --_stg-step: attr(stagger-step type(<time>), var(--stagger-step, 0.07s)); }
+	:where([data-stagger-step])  { --_stg-step: attr(data-stagger-step type(<time>), var(--stagger-step, 0.07s)); }
+	/* typed attr() absent (Safari/FF): keep the step readable — docs: ui/base/polyfills/readme.md */
+	@supports not (transition-delay: attr(x type(<time>), 0s)) {
+		:where([stagger-step], [data-stagger-step]) { --_stg-step: var(--stagger-step, 0.07s); }
+	}
+
 	@media (prefers-reduced-motion: no-preference) {
 		/* === adapter 1: <details> hosts — replay on every [open] ===
 		   Panel forced content-visibility:visible so it stays rendered while closed;
@@ -117,7 +145,7 @@
 				translate var(--stagger-duration, 0.75s) var(--stagger-easing, cubic-bezier(0.16, 1, 0.3, 1)),
 				scale var(--stagger-duration, 0.75s) var(--stagger-easing, cubic-bezier(0.16, 1, 0.3, 1)),
 				filter var(--stagger-duration, 0.75s) var(--stagger-easing, cubic-bezier(0.16, 1, 0.3, 1));
-			transition-delay: calc(var(--stagger-begin, 0s) + (var(--_stg-base-i) + sibling-index() - 1) * var(--stagger-step, 0.07s));
+			transition-delay: calc(var(--stagger-begin, 0s) + (var(--_stg-base-i) + var(--_stg-i) - 1) * var(--_stg-step, var(--stagger-step, 0.07s)));
 		}
 		/* standalone @starting-style — the form that re-fires on each re-open */
 		@starting-style {
@@ -145,7 +173,7 @@
 		/* multi-card slide: give each card its column index (inherits to its content) */
 		:where(ui-card[media*="stagger"], ui-reveal[media*="stagger"]) ui-media > :where(ui-slide, lay-out) > *,
 		ui-media:where([media*="stagger"]) > :where(ui-slide, lay-out) > * {
-			--_stg-crd-i: calc(sibling-index() - 1);
+			--_stg-crd-i: calc(var(--_stg-i) - 1);
 		}
 		/* content children consume the card index as their delay base */
 		:where(ui-card[media*="stagger"], ui-reveal[media*="stagger"]) ui-media ui-content > *,
@@ -163,7 +191,7 @@
 				translate var(--stagger-duration, 0.75s) var(--stagger-easing, cubic-bezier(0.16, 1, 0.3, 1)),
 				scale var(--stagger-duration, 0.75s) var(--stagger-easing, cubic-bezier(0.16, 1, 0.3, 1)),
 				filter var(--stagger-duration, 0.75s) var(--stagger-easing, cubic-bezier(0.16, 1, 0.3, 1));
-			transition-delay: calc(var(--stagger-begin, 0s) + (var(--_stg-base-i) + sibling-index() - 1) * var(--stagger-step, 0.07s));
+			transition-delay: calc(var(--stagger-begin, 0s) + (var(--_stg-base-i) + var(--_stg-i) - 1) * var(--_stg-step, var(--stagger-step, 0.07s)));
 		}
 		/* from-state — held until the slide snaps into the inline viewport */
 		@container not scroll-state(snapped: inline) {
@@ -253,7 +281,7 @@
 				transform-origin: var(--_stg-origin, 50% 50%);
 				animation: ui-stagger-in both var(--stagger-easing, cubic-bezier(0.16, 1, 0.3, 1));
 				animation-timeline: --stg-tl;
-				animation-range: entry calc((sibling-index() - 1) * 20%) entry calc(75% + (sibling-index() - 1) * 20%);
+				animation-range: entry calc((var(--_stg-i) - 1) * 20%) entry calc(75% + (var(--_stg-i) - 1) * 20%);
 			}
 
 			/* --- stagger="… trigger" → one-shot on entry (plays once at full
@@ -280,7 +308,7 @@
 					animation-range: normal;
 					animation-duration: var(--stagger-duration, 0.75s);
 					animation-trigger: --stg-card play-forwards;
-					animation-delay: calc((sibling-index() - 1) * var(--animate-stagger, 10) * var(--animate-delay, 0.005s));
+					animation-delay: calc((var(--_stg-i) - 1) * var(--animate-stagger, 10) * var(--animate-delay, 0.005s));
 				}
 				lay-out[stagger~="trigger"]:not([overflow]):not(:where(details *, ui-media *)) {
 					timeline-trigger: --stg-block view() entry 25% exit 0%;
@@ -291,7 +319,7 @@
 					animation-range: normal;
 					animation-duration: var(--stagger-duration, 0.75s);
 					animation-trigger: --stg-block play-forwards;
-					animation-delay: calc((sibling-index() - 1) * var(--animate-stagger, 10) * var(--animate-delay, 0.005s));
+					animation-delay: calc((var(--_stg-i) - 1) * var(--animate-stagger, 10) * var(--animate-delay, 0.005s));
 				}
 			}
 		}
@@ -305,7 +333,7 @@
 				--_stg-shim-dur: var(--stagger-shimmer-duration, 1s);
 				--_stg-shim-ink: var(--stagger-shimmer-ink, CanvasText);
 				--_stg-shim-spread: var(--stagger-shimmer-spread, 12ch);
-				--_stg-shim-delay: calc(var(--stagger-begin, 0s) + (var(--_stg-base-i) + sibling-index() - 1) * var(--stagger-shimmer-step, 0.9s));
+				--_stg-shim-delay: calc(var(--stagger-begin, 0s) + (var(--_stg-base-i) + var(--_stg-i) - 1) * var(--stagger-shimmer-step, 0.9s));
 				display: var(--_stg-shim-flow, inline);
 				background-image:
 					linear-gradient(var(--_stg-shim-angle, 90deg),

--- a/ui/base/tokens.css
+++ b/ui/base/tokens.css
@@ -152,11 +152,14 @@
 		--ease-in-out: cubic-bezier(0.4, 0, 0.2, 1);
 
 		/* Staggered child reveal (shared: tabs, media carousel, …).
-		   Per-child delay = --stagger-begin + (sibling-index() - 1) * --stagger-step. */
+		   Per-child delay = --stagger-begin + (--_stg-i - 1) * --_stg-step (index/step
+		   default to sibling-index() / --stagger-step, overridable per child). */
 		--stagger-begin: 0s;
 		--stagger-distance: 5rem;
 		--stagger-duration: 0.75s;
 		--stagger-easing: cubic-bezier(0.16, 1, 0.3, 1);
+		/* from-opacity of the reveal; semi/full write the per-channel private forms */
+		--stagger-opacity: 0;
 		--stagger-step: 0.07s;
 
 		/* Shimmer stagger token (stagger="shimmer") — a background-clip:text sweep

--- a/ui/card/data/tokens.data.js
+++ b/ui/card/data/tokens.data.js
@@ -1410,7 +1410,9 @@ export default {
 							"rgt",
 							"zom",
 							"blr",
-							"fde"
+							"fde",
+							"semi",
+							"full"
 						]
 					},
 					"argAliases": {},
@@ -1420,7 +1422,8 @@ export default {
 						"--_stg-tr",
 						"--_stg-sc",
 						"--_stg-fl",
-						"--_stg-origin"
+						"--_stg-origin",
+						"--_stg-op"
 					],
 					"realProperties": false,
 					"cqPrefixes": [],
@@ -1435,9 +1438,9 @@ export default {
 					"deprecated": false,
 					"canonical": null,
 					"sources": [
-						"ui/base/stagger.css:66"
+						"ui/base/stagger.css:83"
 					],
-					"notes": "CONTENT channel of the stagger engine; inert without the `stagger` flag. rise is the unspelled default. The setters are UNSCOPED (:where([media*=\"ani(rise)\"])), so the token also works on a per-slide/per-card element or any ancestor — it only writes inherited custom properties. Mirrors the generic [stagger~=…] word vocabulary 1:1."
+					"notes": "CONTENT channel of the stagger engine; inert without the `stagger` flag. rise is the unspelled default. The setters are UNSCOPED (:where([media*=\"ani(rise)\"])), so the token also works on a per-slide/per-card element or any ancestor — it only writes inherited custom properties. Mirrors the generic [stagger~=…] word vocabulary 1:1. semi/full are MODIFIERS, not effects — they set only the channel's from-opacity (0.5 / 0, the explicit spelling of the default) via --stagger-opacity's private form and compose with any effect word."
 				},
 				"crd": {
 					"axis": "carousel",
@@ -1450,7 +1453,9 @@ export default {
 							"rgt",
 							"zom",
 							"blr",
-							"fde"
+							"fde",
+							"semi",
+							"full"
 						]
 					},
 					"argAliases": {},
@@ -1459,7 +1464,8 @@ export default {
 					"writes": [
 						"--_stg-crd-tr",
 						"--_stg-crd-sc",
-						"--_stg-crd-fl"
+						"--_stg-crd-fl",
+						"--_stg-crd-op"
 					],
 					"realProperties": false,
 					"cqPrefixes": [],
@@ -1474,9 +1480,9 @@ export default {
 					"deprecated": false,
 					"canonical": null,
 					"sources": [
-						"ui/base/stagger.css:74"
+						"ui/base/stagger.css:92"
 					],
-					"notes": "CARD channel — the cards inside a multi-card slide (<ui-slide> or an inner <lay-out>), independent of ani(). Same 7 effects. crd(zom) sets no --_stg-origin (ani(zom) does), so the card zoom uses the default 50% 50% origin."
+					"notes": "CARD channel — the cards inside a multi-card slide (<ui-slide> or an inner <lay-out>), independent of ani(). Same 7 effects. crd(zom) sets no --_stg-origin (ani(zom) does), so the card zoom uses the default 50% 50% origin. semi/full mirror ani(semi)/ani(full): from-opacity modifiers (0.5 / 0), not effects."
 				},
 				"open:grid": {
 					"axis": "open-state",
@@ -1600,9 +1606,9 @@ export default {
 					"deprecated": false,
 					"canonical": null,
 					"sources": [
-						"ui/base/stagger.css:128",
-						"ui/base/stagger.css:143",
-						"ui/base/stagger.css:156"
+						"ui/base/stagger.css:180",
+						"ui/base/stagger.css:185",
+						"ui/base/stagger.css:190"
 					],
 					"notes": "Bare-only in the media= DSL (the equivalent on a <lay-out> is the separate `stagger`/`data-stagger` ATTRIBUTE, which also takes the effect words + `trigger`). Dual arm. Makes each slide a container-type: scroll-state box and holds cards/content at a from-state until @container scroll-state(snapped: inline). Two channels: cards (--_stg-crd-*) and content (--_stg-*). Whole engine is inside @media (prefers-reduced-motion: no-preference). ani()/crd() are separate stems that hang off the same engine."
 				},
@@ -1633,7 +1639,7 @@ export default {
 						"layout/core/base.css:223",
 						"ui/card/media.carousel.css:51",
 						"ui/carousel/carousel.css:186",
-						"ui/base/stagger.css:174"
+						"ui/base/stagger.css:237"
 					],
 					"notes": "One word, one intent — 'this carousel navigates by pages, and adapts on mobile' — with the mechanism following from the markup shape. On <lay-out overflow> (flat children): math paging — snaps + emits one ::scroll-marker per PAGE of --_ci items instead of per item, via mod(sibling-index()-1, --_ci) + if(style(--_pg: 0)); the dot count auto-adapts per breakpoint because --_ci follows columns(N); degrades to per-item where sibling-index()/if() are unsupported. On a <ui-media> scroller (or its card host): the <lay-out> children are PAGE wrappers — below the layout system's md viewport breakpoint (540px) each wrapper dissolves via display:contents, so every card becomes its own full-width snap target with its own dot (grandchild markers collect into the scroller's group natively; a boxless wrapper generates none). ui-media context is CSS-only: slidesOf() still counts the wrapper as ONE slide, so auto/loop don't see through the dissolve; dot markers only (pll/hyb/tmb/lbl stay per-direct-slide). Stagger: each dissolved card becomes its own scroll-state inline-size container — ani() plays per-card, crd() is inert below md. Whole-token ([media~=\"pages\"])."
 				},

--- a/ui/card/data/tokens.json
+++ b/ui/card/data/tokens.json
@@ -1408,7 +1408,9 @@
 							"rgt",
 							"zom",
 							"blr",
-							"fde"
+							"fde",
+							"semi",
+							"full"
 						]
 					},
 					"argAliases": {},
@@ -1418,7 +1420,8 @@
 						"--_stg-tr",
 						"--_stg-sc",
 						"--_stg-fl",
-						"--_stg-origin"
+						"--_stg-origin",
+						"--_stg-op"
 					],
 					"realProperties": false,
 					"cqPrefixes": [],
@@ -1433,9 +1436,9 @@
 					"deprecated": false,
 					"canonical": null,
 					"sources": [
-						"ui/base/stagger.css:66"
+						"ui/base/stagger.css:83"
 					],
-					"notes": "CONTENT channel of the stagger engine; inert without the `stagger` flag. rise is the unspelled default. The setters are UNSCOPED (:where([media*=\"ani(rise)\"])), so the token also works on a per-slide/per-card element or any ancestor — it only writes inherited custom properties. Mirrors the generic [stagger~=…] word vocabulary 1:1."
+					"notes": "CONTENT channel of the stagger engine; inert without the `stagger` flag. rise is the unspelled default. The setters are UNSCOPED (:where([media*=\"ani(rise)\"])), so the token also works on a per-slide/per-card element or any ancestor — it only writes inherited custom properties. Mirrors the generic [stagger~=…] word vocabulary 1:1. semi/full are MODIFIERS, not effects — they set only the channel's from-opacity (0.5 / 0, the explicit spelling of the default) via --stagger-opacity's private form and compose with any effect word."
 				},
 				"crd": {
 					"axis": "carousel",
@@ -1448,7 +1451,9 @@
 							"rgt",
 							"zom",
 							"blr",
-							"fde"
+							"fde",
+							"semi",
+							"full"
 						]
 					},
 					"argAliases": {},
@@ -1457,7 +1462,8 @@
 					"writes": [
 						"--_stg-crd-tr",
 						"--_stg-crd-sc",
-						"--_stg-crd-fl"
+						"--_stg-crd-fl",
+						"--_stg-crd-op"
 					],
 					"realProperties": false,
 					"cqPrefixes": [],
@@ -1472,9 +1478,9 @@
 					"deprecated": false,
 					"canonical": null,
 					"sources": [
-						"ui/base/stagger.css:74"
+						"ui/base/stagger.css:92"
 					],
-					"notes": "CARD channel — the cards inside a multi-card slide (<ui-slide> or an inner <lay-out>), independent of ani(). Same 7 effects. crd(zom) sets no --_stg-origin (ani(zom) does), so the card zoom uses the default 50% 50% origin."
+					"notes": "CARD channel — the cards inside a multi-card slide (<ui-slide> or an inner <lay-out>), independent of ani(). Same 7 effects. crd(zom) sets no --_stg-origin (ani(zom) does), so the card zoom uses the default 50% 50% origin. semi/full mirror ani(semi)/ani(full): from-opacity modifiers (0.5 / 0), not effects."
 				},
 				"open:grid": {
 					"axis": "open-state",
@@ -1598,9 +1604,9 @@
 					"deprecated": false,
 					"canonical": null,
 					"sources": [
-						"ui/base/stagger.css:128",
-						"ui/base/stagger.css:143",
-						"ui/base/stagger.css:156"
+						"ui/base/stagger.css:180",
+						"ui/base/stagger.css:185",
+						"ui/base/stagger.css:190"
 					],
 					"notes": "Bare-only in the media= DSL (the equivalent on a <lay-out> is the separate `stagger`/`data-stagger` ATTRIBUTE, which also takes the effect words + `trigger`). Dual arm. Makes each slide a container-type: scroll-state box and holds cards/content at a from-state until @container scroll-state(snapped: inline). Two channels: cards (--_stg-crd-*) and content (--_stg-*). Whole engine is inside @media (prefers-reduced-motion: no-preference). ani()/crd() are separate stems that hang off the same engine."
 				},
@@ -1631,7 +1637,7 @@
 						"layout/core/base.css:223",
 						"ui/card/media.carousel.css:51",
 						"ui/carousel/carousel.css:186",
-						"ui/base/stagger.css:174"
+						"ui/base/stagger.css:237"
 					],
 					"notes": "One word, one intent — 'this carousel navigates by pages, and adapts on mobile' — with the mechanism following from the markup shape. On <lay-out overflow> (flat children): math paging — snaps + emits one ::scroll-marker per PAGE of --_ci items instead of per item, via mod(sibling-index()-1, --_ci) + if(style(--_pg: 0)); the dot count auto-adapts per breakpoint because --_ci follows columns(N); degrades to per-item where sibling-index()/if() are unsupported. On a <ui-media> scroller (or its card host): the <lay-out> children are PAGE wrappers — below the layout system's md viewport breakpoint (540px) each wrapper dissolves via display:contents, so every card becomes its own full-width snap target with its own dot (grandchild markers collect into the scroller's group natively; a boxless wrapper generates none). ui-media context is CSS-only: slidesOf() still counts the wrapper as ONE slide, so auto/loop don't see through the dissolve; dot markers only (pll/hyb/tmb/lbl stay per-direct-slide). Stagger: each dissolved card becomes its own scroll-state inline-size container — ani() plays per-card, crd() is inert below md. Whole-token ([media~=\"pages\"])."
 				},

--- a/ui/card/demo/media.carousel.html
+++ b/ui/card/demo/media.carousel.html
@@ -777,7 +777,7 @@
 	     STAGGER — content reveal
 	     ════════════════════════════════════════════════════════════ -->
 	<h2 id="stagger">Stagger — content reveal</h2>
-	<p>A card's content reveals on snap; type via <code>ani()</code>: <code>rise</code> · <code>fall</code> · <code>lft</code> · <code>rgt</code> · <code>zom</code> · <code>blr</code> · <code>fde</code>.</p>
+	<p>A card's content reveals on snap; type via <code>ani()</code>: <code>rise</code> · <code>fall</code> · <code>lft</code> · <code>rgt</code> · <code>zom</code> · <code>blr</code> · <code>fde</code> — plus the opacity modifiers <code>semi</code> · <code>full</code>.</p>
 	<lay-out>
 			<ui-media media="asr(16/9) rds(lg) clip nav stagger">
 				<ui-card variant="ovr(bs) rds(non)" media="asr(16/9) obp(cc) scm" content="pad(lg)"><cq-box>
@@ -824,6 +824,21 @@
 				<ui-card variant="ovr(bs) rds(non)" media="asr(4/3) obp(cc) scm ani(blr)" content="pad(lg)"><cq-box>
 					<ui-media><img src="/assets/images/gastronomy.png" alt="" decoding="async" loading="lazy"></ui-media>
 					<ui-content><small data-part="eyebrow">ani(blr)</small><h3 data-part="headline">Unblur</h3><p data-part="summary">Sharpens into focus.</p></ui-content>
+				</cq-box></ui-card>
+			</ui-media>
+	</lay-out>
+
+	<h3>Fade-in from half opacity — <code>ani(fde) ani(semi)</code> · per-child order — <code>data-stagger-index</code></h3>
+	<p>The whole carousel fades its copy in element by element from <code>opacity: 0.5</code>. On the second slide, <code>data-stagger-index</code> reorders the cascade: summary first, headline second, eyebrow last.</p>
+	<lay-out>
+			<ui-media media="asr(16/9) rds(lg) clip nav stagger ani(fde) ani(semi)">
+				<ui-card variant="ovr(bs) rds(non)" media="asr(16/9) obp(cc) scm" content="pad(lg)"><cq-box>
+					<ui-media><img src="/assets/images/river.png" alt="" decoding="async" loading="lazy"></ui-media>
+					<ui-content><small data-part="eyebrow">ani(fde) ani(semi)</small><h3 data-part="headline">Half fade</h3><p data-part="summary">No movement — lines settle from semi-opaque to solid, one by one.</p></ui-content>
+				</cq-box></ui-card>
+				<ui-card variant="ovr(bs) rds(non)" media="asr(16/9) obp(cc) scm" content="pad(lg)"><cq-box>
+					<ui-media><img src="/assets/images/mindfulness.png" alt="" decoding="async" loading="lazy"></ui-media>
+					<ui-content><small data-part="eyebrow" data-stagger-index="3">Appears last</small><h3 data-part="headline" data-stagger-index="2">Appears second</h3><p data-part="summary" data-stagger-index="1">Appears first — the cascade reads bottom-up here.</p></ui-content>
 				</cq-box></ui-card>
 			</ui-media>
 	</lay-out>
@@ -1037,19 +1052,19 @@
 	<p>Each page is its own <code>&lt;lay-out&gt;</code> grid inside a <code>stagger pages</code> scroller — a whole grid reveals per snap. Below <code>md</code> (540px) the pages dissolve and every card becomes its own slide; narrow the window to watch the dot count jump.</p>
 
 	<h4>Two channels — <code>crd()</code> + <code>ani()</code></h4>
-	<p><code>crd()</code> animates the cards, <code>ani()</code> their content; both cascade.</p>
+	<p><code>crd()</code> animates the cards, <code>ani()</code> their content; both cascade. On the first page the cards carry a bare <code>stagger-index</code> (custom elements take the bare spelling), so the middle card leads the card cascade.</p>
 	<lay-out>
 			<ui-media class="slide-gap" media="nav stagger crd(rise) pages">
 				<lay-out md="columns(3)" stagger>
-					<ui-card variant="ovr(bs) rds(md-sq)" media="asr(3/4) obp(cc) scm ani(fall)" content="scl(sm) pad(md)"><cq-box>
+					<ui-card stagger-index="2" variant="ovr(bs) rds(md-sq)" media="asr(3/4) obp(cc) scm ani(fall)" content="scl(sm) pad(md)"><cq-box>
 						<ui-media><img src="/assets/images/hubble.png" alt="" decoding="async" loading="lazy"></ui-media>
 						<ui-content><small data-part="eyebrow">Space · ani(fall)</small><h3 data-part="headline">Hubble</h3></ui-content>
 					</cq-box></ui-card>
-					<ui-card variant="ovr(bs) rds(md-sq)" media="asr(3/4) obp(cc) scm ani(fall)" content="scl(sm) pad(md)"><cq-box>
+					<ui-card stagger-index="1" variant="ovr(bs) rds(md-sq)" media="asr(3/4) obp(cc) scm ani(fall)" content="scl(sm) pad(md)"><cq-box>
 						<ui-media><img src="/assets/images/quantum.png" alt="" decoding="async" loading="lazy"></ui-media>
 						<ui-content><small data-part="eyebrow">Physics · ani(fall)</small><h3 data-part="headline">Quantum</h3></ui-content>
 					</cq-box></ui-card>
-					<ui-card variant="ovr(bs) rds(md-sq)" media="asr(3/4) obp(cc) scm ani(fall)" content="scl(sm) pad(md)"><cq-box>
+					<ui-card stagger-index="3" variant="ovr(bs) rds(md-sq)" media="asr(3/4) obp(cc) scm ani(fall)" content="scl(sm) pad(md)"><cq-box>
 						<ui-media><img src="/assets/images/websummit.png" alt="" decoding="async" loading="lazy"></ui-media>
 						<ui-content><small data-part="eyebrow">Tech · ani(fall)</small><h3 data-part="headline">Web Summit</h3></ui-content>
 					</cq-box></ui-card>

--- a/ui/card/docs/carousel.md
+++ b/ui/card/docs/carousel.md
@@ -81,8 +81,8 @@ inventory cannot drift from the CSS. The prose tables under it explain what the 
 | `tmb()` | thumbs | **ratio** 1/1 4/3 3/4 16/9 3/2 2/3 | — | — | --ui-carousel-thumb-ratio --ui-carousel-thumb-ratio-n | — | — |
 | `axis()` | carousel | **value** y | — | — | — | — | — |
 | `auto()` | carousel | **value** &lt;n&gt; &lt;n&gt;s &lt;n&gt;ms | — | yes | --ui-carousel-autoplay --ui-carousel-play-state --ui-carousel-thumb-timer-name --_play-block --_play-inline --_play-justify --_play-size | — | — |
-| `ani()` | carousel | **anim** rise fall lft rgt zom blr fde | — | — | --_stg-tr --_stg-sc --_stg-fl --_stg-origin | — | — |
-| `crd()` | carousel | **anim** rise fall lft rgt zom blr fde | — | — | --_stg-crd-tr --_stg-crd-sc --_stg-crd-fl | — | — |
+| `ani()` | carousel | **anim** rise fall lft rgt zom blr fde semi full | — | — | --_stg-tr --_stg-sc --_stg-fl --_stg-origin --_stg-op | — | — |
+| `crd()` | carousel | **anim** rise fall lft rgt zom blr fde semi full | — | — | --_stg-crd-tr --_stg-crd-sc --_stg-crd-fl --_stg-crd-op | — | — |
 | `load()` | loading | **mode** eager lazy | — | — | — | — | — |
 | `clip` | corners | — | — | yes | --ui-media-radius | — | — |
 | `loop` | carousel | — | — | yes | --_play-block --_play-inline --_play-justify --_play-size | — | — |

--- a/ui/card/docs/media.carousel.md
+++ b/ui/card/docs/media.carousel.md
@@ -40,8 +40,8 @@ media.md.)
 
 | `media=` token | Layer | Effect |
 |----------------|-------|--------|
-| `ani(<type>)` | CSS | `stagger` **content** reveal type: `rise` (default) · `fall` · `lft` · `rgt` · `zom` · `blr` · `fde` (see "Staggered content reveal") |
-| `crd(<type>)` | CSS | `stagger` **card** reveal type (multi-card slides) — same vocabulary, independent of `ani()` |
+| `ani(<type>)` | CSS | `stagger` **content** reveal type: `rise` (default) · `fall` · `lft` · `rgt` · `zom` · `blr` · `fde` — plus the modifiers `semi` · `full` (see "Staggered content reveal") |
+| `crd(<type>)` | CSS | `stagger` **card** reveal type (multi-card slides) — same vocabulary (+ modifiers), independent of `ani()` |
 | `arw(arr)`  | CSS | Full-arrow glyph (default is chevron — no token) |
 | `arw(bare)` | CSS | Drop the circle — glyph painted as a recolourable shape (`--ui-carousel-arrow-color`) |
 | `arw(bc)`   | CSS | Split arrows, bottom band (block row) |
@@ -658,9 +658,13 @@ Shares the global tokens from `ui/base/tokens.css`:
 | `--stagger-distance` | `5rem` | Travel distance (`translate` start for rise/fall/lft/rgt) |
 | `--stagger-duration` | `0.75s` | Per-child fade/rise duration |
 | `--stagger-easing` | `cubic-bezier(0.16, 1, 0.3, 1)` | Easing |
+| `--stagger-opacity` | `0` | From-opacity of the reveal (both channels) |
 | `--stagger-step` | `0.07s` | Delay added per child |
 
-Per-child delay = `--stagger-begin + (sibling-index() - 1) * --stagger-step`.
+Per-child delay = `--stagger-begin + (index - 1) * step` — index defaults to
+`sibling-index()` and step to `--stagger-step`, each overridable per child via the
+`stagger-index=` / `stagger-step=` attributes (typed `attr()`; see
+[stagger.md § Per-child overrides](./stagger.md#per-child-overrides)).
 
 **Reveal type — `ani(<type>)`.** The hidden "from" state is driven by private vars
 (`--_stg-tr` translate · `--_stg-sc` scale · `--_stg-fl` filter), so `ani()` just swaps them —
@@ -676,6 +680,14 @@ the content rule already transitions `opacity`/`translate`/`scale`/`filter`. Com
 | `ani(zom)` | `scale: 0.65` | zoom / scale up |
 | `ani(blr)` | `filter: blur(12px)` | blur + fade |
 | `ani(fde)` | — (opacity only) | plain fade |
+
+**Opacity modifiers — `ani(semi)` / `ani(full)`.** Not effects: they set only the
+channel's from-opacity — `semi` starts children semi-opaque (`opacity: 0.5`), `full`
+is the explicit spelling of the default (`0`). Compose with any effect word; the
+canonical pairing is the element-by-element fade,
+`media="… stagger ani(fde) ani(semi)"`. The card channel mirrors them as
+`crd(semi)` / `crd(full)`. Both write private forms over the shared
+`--stagger-opacity` token.
 
 Set `ani()` on the **carousel** for one shared reveal, or on an **individual slide's**
 `media=` for a per-slide reveal — the setter is element-level (`:where([media*="ani(x)"])`),

--- a/ui/card/docs/media.md
+++ b/ui/card/docs/media.md
@@ -151,8 +151,8 @@ drift from the CSS. (`md:/lg:` is the container-query prefix column: only `asr()
 | `tmb()` | thumbs | **ratio** 1/1 4/3 3/4 16/9 3/2 2/3 | — | — | --ui-carousel-thumb-ratio --ui-carousel-thumb-ratio-n | — | — |
 | `axis()` | carousel | **value** y | — | — | — | — | — |
 | `auto()` | carousel | **value** &lt;n&gt; &lt;n&gt;s &lt;n&gt;ms | — | yes | --ui-carousel-autoplay --ui-carousel-play-state --ui-carousel-thumb-timer-name --_play-block --_play-inline --_play-justify --_play-size | — | — |
-| `ani()` | carousel | **anim** rise fall lft rgt zom blr fde | — | — | --_stg-tr --_stg-sc --_stg-fl --_stg-origin | — | — |
-| `crd()` | carousel | **anim** rise fall lft rgt zom blr fde | — | — | --_stg-crd-tr --_stg-crd-sc --_stg-crd-fl | — | — |
+| `ani()` | carousel | **anim** rise fall lft rgt zom blr fde semi full | — | — | --_stg-tr --_stg-sc --_stg-fl --_stg-origin --_stg-op | — | — |
+| `crd()` | carousel | **anim** rise fall lft rgt zom blr fde semi full | — | — | --_stg-crd-tr --_stg-crd-sc --_stg-crd-fl --_stg-crd-op | — | — |
 | `open:grid()` | open-state | **cols** 2c 3c 4c | — | — | --_lb-cols | — | — |
 | `clip` | corners | — | — | yes | --ui-media-radius | — | — |
 | `loop` | carousel | — | — | yes | --_play-block --_play-inline --_play-justify --_play-size | — | — |

--- a/ui/card/docs/stagger.md
+++ b/ui/card/docs/stagger.md
@@ -37,12 +37,36 @@ Tokens are attribute **values**, matched with `~=` (whole word). Bare `stagger`
 | `blr` | `filter: blur(12px)` | blur + fade |
 | `fde` | — (opacity only) | plain fade |
 | `shimmer` (+ `sweep`) | *(text effect, `<details>` hosts only — see [Shimmer](#shimmer))* | the text lights up, line by line |
+| `semi` | *(modifier — from `opacity: 0.5`)* | start semi-opaque; composes with any effect |
+| `full` | *(modifier — from `opacity: 0`)* | the explicit spelling of the default |
 
 `<d>` = `var(--stagger-distance)`. Each token sets **inherited** private vectors —
 `--_stg-tr` (translate) · `--_stg-sc` (scale) · `--_stg-fl` (filter) · `--_stg-origin`
 (transform-origin). Because they inherit, a token may sit on the group **or any
 ancestor**, and every adapter's from-state reads the same three vars — that's why one
 vocabulary drives all three triggers.
+
+### Fade-in opacity (`semi` / `full`)
+
+`semi` and `full` are **modifiers, not effects**: they set only the from-opacity of the
+reveal — `semi` starts children at `opacity: 0.5`, `full` at `0` (the explicit spelling of
+the default). They compose with any effect word; the canonical pairing is the
+element-by-element fade:
+
+```html
+<div data-stagger="fde semi">
+  <p>…</p>
+  <p>…</p>
+</div>
+```
+
+In the media DSL they mirror 1:1 as `ani(semi)` / `ani(full)` (content channel) and
+`crd(semi)` / `crd(full)` (card channel) — `media="… stagger ani(fde) ani(semi)"`. Under
+the hood the modifiers write per-channel private forms (`--_stg-op` content,
+`--_stg-crd-op` card) over the shared public token `--stagger-opacity`, which every
+adapter's from-state (and the `ui-stagger-in` keyframe) reads — so an arbitrary
+from-opacity can also be themed directly: `--stagger-opacity: 0.25`. Shimmer is
+unaffected (its from-states keep `opacity: 1` — it paints, it doesn't fade).
 
 ## Tokens
 
@@ -55,13 +79,75 @@ engine survives the token-less `layout.css` bundle):
 | `--stagger-distance` | `5rem` | Travel distance for the translate tokens |
 | `--stagger-duration` | `0.75s` | Per-child duration |
 | `--stagger-easing` | `cubic-bezier(0.16, 1, 0.3, 1)` | Easing |
+| `--stagger-opacity` | `0` | From-opacity of the reveal (`semi`/`full` write the per-channel private forms) |
 | `--stagger-step` | `0.07s` | Delay added per child |
 
-**Per-child delay** = `--stagger-begin + (--_stg-base-i + sibling-index() - 1) * --stagger-step`.
+**Per-child delay** = `--stagger-begin + (--_stg-base-i + --_stg-i - 1) * --_stg-step`.
 
-`--_stg-base-i` (registered `<integer>`, non-inherited, initial `0`) lets a host offset
-the cascade — the card carousel bridges its **card index** into it so a card's content
-picks up where the card left off (see adapter 2).
+- `--_stg-base-i` (registered `<integer>`, non-inherited, initial `0`) lets a host offset
+  the cascade — the card carousel bridges its **card index** into it so a card's content
+  picks up where the card left off (see adapter 2).
+- `--_stg-i` (registered `<integer>`, non-inherited, initial `1`) is the child's cascade
+  index — `sibling-index()` unless overridden by attribute.
+- `--_stg-step` (unregistered) is the child's step — `--stagger-step` unless overridden
+  by attribute.
+
+## Per-child overrides
+
+Two attributes on a **child** override its slot in the cascade, read in CSS via typed
+`attr()` (same mechanism as `tint=` — bare spelling on custom elements, `data-` on
+native ones):
+
+| Attribute | Type | Overrides | Effect |
+|---|---|---|---|
+| `stagger-index` / `data-stagger-index` | `<integer>` | `sibling-index()` | reorder — delay slot only, DOM/paint order unchanged |
+| `stagger-step` / `data-stagger-step` | `<time>` | `--stagger-step` | pace — `delay = begin + (index - 1) × own step` |
+
+```html
+<!-- cascade order 2, 1, 3 -->
+<div data-stagger>
+  <p data-stagger-index="2">appears second</p>
+  <p data-stagger-index="1">appears first</p>
+  <p data-stagger-index="3">appears third</p>
+</div>
+
+<!-- mixed pace: quick · default · extremely slow -->
+<div data-stagger>
+  <p data-stagger-step="0.02s">…</p>
+  <p>…</p>
+  <p data-stagger-step="0.6s">…</p>
+</div>
+```
+
+A child's step scales its **own** whole delay, so a big step on a late child lands it
+after everyone (extremely slow), and a child with a large index but tiny step can still
+arrive early — the two compose, they don't fight.
+
+**Adapter coverage.** The index override applies everywhere a sibling term exists; the
+step override only where the delay is a real `<time>`:
+
+| Site | `stagger-index` | `stagger-step` |
+|---|---|---|
+| adapter 1 (`<details>`) transition delay | ✓ | ✓ |
+| adapter 2 (snap carousel) — cards **and** content | ✓ | ✓ |
+| adapter 3 (`<lay-out stagger>`) scrubbed `animation-range` | ✓ | — (percent-based, no time term) |
+| adapter 3 `stagger="… trigger"` one-shot delay | ✓ | — (paced by `--animate-stagger`/`--animate-delay`) |
+| shimmer delay | ✓ | — (shimmer keeps `--stagger-shimmer-step`) |
+
+Details that matter:
+
+- **`--_stg-i` does not inherit** (registered, `inherits: false`) — a nested stagger
+  host's children compute their own indices; a parent's override never leaks in. On an
+  adapter-2 **card**, `stagger-index` reorders the card *and* re-bases its content
+  (`--_stg-crd-i` derives from it).
+- **`--_stg-step` does inherit** (unregistered by necessity — registering would kill the
+  `--stagger-step` theming fallback). A step attribute on a group therefore also paces
+  nested subjects, consistent with the engine's "a token may sit on any ancestor" design.
+- **Safari/Firefox** (no typed `attr()`, no `sibling-index()`): the index degrades to a
+  uniform cascade (`--_stg-i` self-heals to its initial `1` — same as those browsers get
+  today), the step falls back to the default `--stagger-step` via a CSS-only `@supports`
+  guard, and `ui/base/polyfills/attr-fallback.js` restores the exact authored values on
+  top. See [`ui/base/polyfills/readme.md`](../../base/polyfills/readme.md).
 
 ---
 

--- a/ui/card/docs/tokens.md
+++ b/ui/card/docs/tokens.md
@@ -38,8 +38,8 @@ sit on. Notes below each table carry the per-token caveats.
 | `tmb()` | thumbs | **ratio** 1/1 4/3 3/4 16/9 3/2 2/3 | — | — | --ui-carousel-thumb-ratio --ui-carousel-thumb-ratio-n | — | ui-media ui-card ui-reveal lay-out[overflow] | — | — |
 | `axis()` | carousel | **value** y | — | — | — | — | ui-media ui-card ui-reveal lay-out[overflow] | — | — |
 | `auto()` | carousel | **value** &lt;n&gt; &lt;n&gt;s &lt;n&gt;ms | — | yes | --ui-carousel-autoplay --ui-carousel-play-state --ui-carousel-thumb-timer-name --_play-block --_play-inline --_play-justify --_play-size | — | ui-media ui-card ui-reveal lay-out[overflow] | carousel.js (*) | — |
-| `ani()` | carousel | **anim** rise fall lft rgt zom blr fde | — | — | --_stg-tr --_stg-sc --_stg-fl --_stg-origin | — | ui-media ui-card ui-reveal | — | — |
-| `crd()` | carousel | **anim** rise fall lft rgt zom blr fde | — | — | --_stg-crd-tr --_stg-crd-sc --_stg-crd-fl | — | ui-media ui-card ui-reveal | — | — |
+| `ani()` | carousel | **anim** rise fall lft rgt zom blr fde semi full | — | — | --_stg-tr --_stg-sc --_stg-fl --_stg-origin --_stg-op | — | ui-media ui-card ui-reveal | — | — |
+| `crd()` | carousel | **anim** rise fall lft rgt zom blr fde semi full | — | — | --_stg-crd-tr --_stg-crd-sc --_stg-crd-fl --_stg-crd-op | — | ui-media ui-card ui-reveal | — | — |
 | `open:grid()` | open-state | **cols** 2c 3c 4c | — | — | --_lb-cols | — | ui-media ui-card ui-reveal | — | — |
 | `clip` | corners | — | — | yes | --ui-media-radius | — | ui-media | — | — |
 | `loop` | carousel | — | — | yes | --_play-block --_play-inline --_play-justify --_play-size | — | ui-media ui-card ui-reveal lay-out[overflow] | carousel.js (*) | — |
@@ -121,11 +121,11 @@ sit on. Notes below each table carry the per-token caveats.
 **`auto`** *(substring-matched, self arm)* — Matched as :is([media~="auto"], [media*="auto("]) in BOTH the CSS sticky-<ui-play> rule (media.carousel.css:75-76) and carousel.js — the stem-scoped `auto(` needle is the parameterized half, the bare half is whole-token. JS parses the duration with /(?:^|\s)auto(?:\((\d+(?:\.\d+)?)(m?s)?\))?/, so a bare number means SECONDS. Default 5s. No-ops under prefers-reduced-motion and with <2 slides. The three --ui-carousel-* writes are inline styles set by carousel.js, not CSS. The CSS arm is deliberately NOT factored: the host arm excludes nested frames (:not(ui-media ui-media)), the self arm doesn't.
 <sub>ui/card/media.carousel.css:75 · ui/card/carousel.js:82 · ui/card/carousel.js:160</sub>
 
-**`ani`** *(substring-matched, self arm)* — CONTENT channel of the stagger engine; inert without the `stagger` flag. rise is the unspelled default. The setters are UNSCOPED (:where([media*="ani(rise)"])), so the token also works on a per-slide/per-card element or any ancestor — it only writes inherited custom properties. Mirrors the generic [stagger~=…] word vocabulary 1:1.
-<sub>ui/base/stagger.css:66</sub>
+**`ani`** *(substring-matched, self arm)* — CONTENT channel of the stagger engine; inert without the `stagger` flag. rise is the unspelled default. The setters are UNSCOPED (:where([media*="ani(rise)"])), so the token also works on a per-slide/per-card element or any ancestor — it only writes inherited custom properties. Mirrors the generic [stagger~=…] word vocabulary 1:1. semi/full are MODIFIERS, not effects — they set only the channel's from-opacity (0.5 / 0, the explicit spelling of the default) via --stagger-opacity's private form and compose with any effect word.
+<sub>ui/base/stagger.css:83</sub>
 
-**`crd`** *(substring-matched, self arm)* — CARD channel — the cards inside a multi-card slide (<ui-slide> or an inner <lay-out>), independent of ani(). Same 7 effects. crd(zom) sets no --_stg-origin (ani(zom) does), so the card zoom uses the default 50% 50% origin.
-<sub>ui/base/stagger.css:74</sub>
+**`crd`** *(substring-matched, self arm)* — CARD channel — the cards inside a multi-card slide (<ui-slide> or an inner <lay-out>), independent of ani(). Same 7 effects. crd(zom) sets no --_stg-origin (ani(zom) does), so the card zoom uses the default 50% 50% origin. semi/full mirror ani(semi)/ani(full): from-opacity modifiers (0.5 / 0), not effects.
+<sub>ui/base/stagger.css:92</sub>
 
 **`open:grid`** *(whole-matched, self arm)* — OPEN-STATE prefix family (media.lightbox.css): arms only while the <ui-media popover> frame is :popover-open, presenting the SAME children as an N-column scrollable grid instead of the default fullscreen carousel. WHOLE-token on purpose, like md:/lg: asr() — an open: spelling must never contain a substring-matched stem, which is why there is no open:nav (the [media*="nav"] needle would arm the closed carousel; fullscreen carousel is simply the default open presentation of a nav frame). The colon lives in the entry NAME so the needle audit and preset lint see the literal spellings; the cqPrefixes machinery is deliberately not reused (that is the container-query axis, and it would hide substring cross-fire from the shadow lint). Runtime carousel↔grid switching (data-lightbox attr) needs ui/card/lightbox.js.
 <sub>ui/card/media.lightbox.css:112 · ui/card/media.lightbox.css:127</sub>
@@ -137,10 +137,10 @@ sit on. Notes below each table carry the per-token caveats.
 <sub>ui/card/media.carousel.css:75 · ui/card/carousel.js:44 · ui/card/carousel.js:161</sub>
 
 **`stagger`** *(substring-matched, self arm)* — Bare-only in the media= DSL (the equivalent on a <lay-out> is the separate `stagger`/`data-stagger` ATTRIBUTE, which also takes the effect words + `trigger`). Dual arm. Makes each slide a container-type: scroll-state box and holds cards/content at a from-state until @container scroll-state(snapped: inline). Two channels: cards (--_stg-crd-*) and content (--_stg-*). Whole engine is inside @media (prefers-reduced-motion: no-preference). ani()/crd() are separate stems that hang off the same engine.
-<sub>ui/base/stagger.css:128 · ui/base/stagger.css:143 · ui/base/stagger.css:156</sub>
+<sub>ui/base/stagger.css:180 · ui/base/stagger.css:185 · ui/base/stagger.css:190</sub>
 
 **`pages`** *(whole-matched, self arm)* — One word, one intent — 'this carousel navigates by pages, and adapts on mobile' — with the mechanism following from the markup shape. On <lay-out overflow> (flat children): math paging — snaps + emits one ::scroll-marker per PAGE of --_ci items instead of per item, via mod(sibling-index()-1, --_ci) + if(style(--_pg: 0)); the dot count auto-adapts per breakpoint because --_ci follows columns(N); degrades to per-item where sibling-index()/if() are unsupported. On a <ui-media> scroller (or its card host): the <lay-out> children are PAGE wrappers — below the layout system's md viewport breakpoint (540px) each wrapper dissolves via display:contents, so every card becomes its own full-width snap target with its own dot (grandchild markers collect into the scroller's group natively; a boxless wrapper generates none). ui-media context is CSS-only: slidesOf() still counts the wrapper as ONE slide, so auto/loop don't see through the dissolve; dot markers only (pll/hyb/tmb/lbl stay per-direct-slide). Stagger: each dissolved card becomes its own scroll-state inline-size container — ani() plays per-card, crd() is inert below md. Whole-token ([media~="pages"]).
-<sub>layout/core/base.css:223 · ui/card/media.carousel.css:51 · ui/carousel/carousel.css:186 · ui/base/stagger.css:174</sub>
+<sub>layout/core/base.css:223 · ui/card/media.carousel.css:51 · ui/carousel/carousel.css:186 · ui/base/stagger.css:237</sub>
 
 **`open:furniture`** *(whole-matched, self arm)* — OPT-OUT of the lightbox's default furniture hiding: while a frame is :popover-open, direct-child ui-chip/ui-sticker/ui-beacon/ui-marquee/ui-save are display:none unless this bare flag is present (ui-play and ui-lightbox always stay — video control and close affordance). Whole-token, open-state family — see open:grid.
 <sub>ui/card/media.lightbox.css:101</sub>


### PR DESCRIPTION
Adds per-child cascade control and fade-opacity variants to the shared stagger engine (`ui/base/stagger.css`), across all three trigger adapters.

## What's new

### Per-child overrides (typed `attr()`, `tint=` precedent)

| Attribute | Type | Effect |
|---|---|---|
| `stagger-index=` / `data-stagger-index=` | `<integer>` | Reorders the cascade (2, 1, 3 …) — delay slot only, DOM/paint order unchanged |
| `stagger-step=` / `data-stagger-step=` | `<time>` | Paces one child: `delay = begin + (index − 1) × own step` — quick, slower, extremely slow |

- New registered `--_stg-i` (`<integer>`, `inherits: false`, initial `1`) defaults to `sibling-index()` and replaces it in every formula: both `transition-delay`s, the carousel card index (`--_stg-crd-i`), adapter 3's `animation-range` and trigger delays, and the shimmer delay. Non-inheriting, so a parent's override never leaks into nested stagger hosts.
- `--_stg-step` stays unregistered on purpose (registering would kill the `--stagger-step` theming fallback chain); a CSS-only `@supports not (transition-delay: attr(x type(<time>), 0s))` guard keeps the step readable where typed `attr()` is unsupported.
- Defaults are 0-0-0 `:where()` rules declared before the attribute readers, so source order resolves the override — kept out of the details adapter's real-specificity rules.

### `semi` / `full` fade-opacity modifiers

- `stagger="fde semi"` (and DSL mirrors `ani(semi)` / `crd(semi)`, plus explicit `full`) start the reveal from `opacity: 0.5` instead of `0` — lines/children fade in element by element from semi-opaque. Composes with any effect word.
- Backed by a new public token `--stagger-opacity` (default `0`) read by all three adapters' from-states and the `ui-stagger-in` keyframe; the modifiers write per-channel private forms (`--_stg-op` content / `--_stg-crd-op` card) on top, mirroring the vector-channel split.

## Commits

1. `57ecf58` — engine: index/step overrides, `@supports` guard, `attr-fallback.js` entries + readme degradation story
2. `b2b2e94` — engine: `semi`/`full` + `--stagger-opacity`, manifest (`ani()`/`crd()` args) + regenerated artifacts
3. `c343ab0` — docs (`stagger.md` *Per-child overrides* section, `media.carousel.md`) + demos (`ui/accordion/index.html`, `ui/card/demo/media.carousel.html`)

## Verification

- `tokens.build.js` idempotent (second run no-op), `tokens.lint.js` ok, SSR snapshot byte-identical.
- Measured in Chromium 141: reordered delays `0.07s / 0s / 0.14s` follow index 2/1/3; pace mix `0s / 0.07s / 1.2s`; `semi` from-state computes `opacity: 0.5` on an un-snapped slide, `1` after reveal; card-channel `--_stg-crd-i` = `1 / 0 / 2` under override; nested hosts don't inherit a parent's index; zero console errors on the three touched demo pages; RTL spot-check clean; reduced-motion renders instantly visible.
- The `attr(… type(<integer>), sibling-index())` fallback form works in Chromium — shipped as planned.
- Safari/Firefox degradation: index self-heals to a uniform cascade (same as today, `sibling-index()` unsupported), step falls back to `--stagger-step` CSS-only; `ui/base/polyfills/attr-fallback.js` restores exact authored values on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AgDVSQDSMXDDXmvxuMDhLT

---
_Generated by [Claude Code](https://claude.ai/code/session_01AgDVSQDSMXDDXmvxuMDhLT)_