### PR TITLE
accordion demo: fold stagger override panels into "Staggered panel content"

### DIFF
--- a/ui/accordion/index.html
+++ b/ui/accordion/index.html
@@ -811,39 +811,6 @@
 	</auto-morph>
 
 	<br>
-	<h2>Stagger: per-child overrides + fade opacity</h2>
-	<p>Per-child overrides on the shared stagger engine, read via typed <code>attr()</code>: <code>data-stagger-index</code> reorders the cascade, <code>data-stagger-step</code> paces a single child, and <code>data-stagger="fde semi"</code> fades in element by element from half opacity.</p>
-
-	<ui-accordion group="accordion-overrides" variant="bordered divided rounded">
-		<cq-box>
-			<details name="accordion-overrides" open>
-				<summary>Reordered cascade (2, 1, 3)<ui-icon type="plus-minus"></ui-icon></summary>
-				<div data-stagger>
-					<p data-stagger-index="2">Second to appear — although it is the first paragraph in the DOM, its <code>data-stagger-index="2"</code> puts it in the middle of the cascade.</p>
-					<p data-stagger-index="1">First to appear — <code>data-stagger-index="1"</code> pulls it ahead of the paragraph above it.</p>
-					<p data-stagger-index="3">Third to appear — <code>data-stagger-index="3"</code> keeps it last, exactly where the DOM would have put it anyway.</p>
-				</div>
-			</details>
-			<details name="accordion-overrides">
-				<summary>Per-child pace<ui-icon type="plus-minus"></ui-icon></summary>
-				<div data-stagger>
-					<p data-stagger-step="0.02s">Quick — <code>data-stagger-step="0.02s"</code> makes this child's whole delay tiny.</p>
-					<p>Default — no attribute, so this child paces off the shared <code>--stagger-step</code>.</p>
-					<p data-stagger-step="0.6s">Extremely slow — <code>data-stagger-step="0.6s"</code> scales this child's delay to 1.2s.</p>
-				</div>
-			</details>
-			<details name="accordion-overrides">
-				<summary>Fade in from half opacity<ui-icon type="plus-minus"></ui-icon></summary>
-				<div data-stagger="fde semi">
-					<p>These lines fade in one after another — no movement, just opacity.</p>
-					<p>The <code>semi</code> modifier starts them at <code>opacity: 0.5</code> instead of fully hidden.</p>
-					<p>Drop the modifier (or spell it <code>full</code>) for the default fade from <code>opacity: 0</code>.</p>
-				</div>
-			</details>
-		</cq-box>
-	</ui-accordion>
-
-	<br>
 	<p>With <code>tabs="ellipse"</code> and classes <code>tabs-fill-surface tabs-offset</code> — panels stagger with <code>data-stagger="fall"</code>:</p>
 	<auto-morph render="tabs">
 		<ui-accordion group="accordion-tabs-ellipse" class="tabs-fill-surface tabs-offset" variant="bordered divided rounded" tabs="ellipse">
@@ -1155,6 +1122,30 @@
 					<p><strong>One band, crossing every line at once.</strong></p>
 					<p>Children stay blocks and the band is tilted, so a whole box lights up together rather than being read through.</p>
 					<p>Layout is untouched, so any number of children is safe.</p>
+				</div>
+			</details>
+			<details name="accordion-stagger">
+				<summary>Reordered cascade (2, 1, 3)<ui-icon type="plus-minus"></ui-icon></summary>
+				<div data-stagger>
+					<p data-stagger-index="2">Second to appear — although it is the first paragraph in the DOM, its <code>data-stagger-index="2"</code> puts it in the middle of the cascade.</p>
+					<p data-stagger-index="1">First to appear — <code>data-stagger-index="1"</code> pulls it ahead of the paragraph above it.</p>
+					<p data-stagger-index="3">Third to appear — <code>data-stagger-index="3"</code> keeps it last, exactly where the DOM would have put it anyway.</p>
+				</div>
+			</details>
+			<details name="accordion-stagger">
+				<summary>Per-child pace<ui-icon type="plus-minus"></ui-icon></summary>
+				<div data-stagger>
+					<p data-stagger-step="0.02s">Quick — <code>data-stagger-step="0.02s"</code> makes this child's whole delay tiny.</p>
+					<p>Default — no attribute, so this child paces off the shared <code>--stagger-step</code>.</p>
+					<p data-stagger-step="0.6s">Extremely slow — <code>data-stagger-step="0.6s"</code> scales this child's delay to 1.2s.</p>
+				</div>
+			</details>
+			<details name="accordion-stagger">
+				<summary>Fade in from half opacity<ui-icon type="plus-minus"></ui-icon></summary>
+				<div data-stagger="fde semi">
+					<p>These lines fade in one after another — no movement, just opacity.</p>
+					<p>The <code>semi</code> modifier starts them at <code>opacity: 0.5</code> instead of fully hidden.</p>
+					<p>Drop the modifier (or spell it <code>full</code>) for the default fade from <code>opacity: 0</code>.</p>
 				</div>
 			</details>
 		</cq-box>


### PR DESCRIPTION
Follow-up to #34, demo placement only. The per-child override demos in `ui/accordion/index.html` shipped as a dedicated section (own `<h2>`, intro text, own accordion group); they belong with the rest of the stagger effect panels instead.

- Moved the three panels — *Reordered cascade (2, 1, 3)*, *Per-child pace*, *Fade in from half opacity* — into the existing "Staggered panel content" accordion (`accordion-stagger` group), after *Shimmer sweep*, matching the neighbors' format.
- Removed the dedicated section entirely; no intro text added.

Verified in Chromium (fresh port): the moved panels still measure `transition-delay` `0.07s / 0s / 0.14s` (reorder) and `0s / 0.07s / 1.2s` (pace), `fde semi` starts at `opacity: 0.5` and settles to `1`, no remnants of the old `accordion-overrides` group, zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AgDVSQDSMXDDXmvxuMDhLT

---
_Generated by [Claude Code](https://claude.ai/code/session_01AgDVSQDSMXDDXmvxuMDhLT)_